### PR TITLE
fix: Release pipeline master always merge issue

### DIFF
--- a/packs/typescript/.lighthouse/jenkins-x/release.yaml
+++ b/packs/typescript/.lighthouse/jenkins-x/release.yaml
@@ -204,7 +204,7 @@ spec:
           - --baseSHA
           - $(params.PULL_BASE_SHA)
           - --sha
-          - $(params.PULL_PULL_SHA)
+          - $(params.PULL_BASE_REF)
           - --baseBranch
           - $(params.PULL_BASE_REF)
           command:


### PR DESCRIPTION
Release pipeline git-merge step merges master to base_branch(on which release is made)
Fixes this for typescript  #2