### PR TITLE
fix: add missing volume to nop pack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Binaries for programs and plugins
 *.exe
-*~
+*.exe~
 *.dll
 *.so
 *.dylib

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Binaries for programs and plugins
 *.exe
-*.exe~
+*~
 *.dll
 *.so
 *.dylib

--- a/packs/nop/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/nop/.lighthouse/jenkins-x/pullrequest.yaml
@@ -234,6 +234,8 @@ spec:
           name: build-dummy-build
           resources: {}
         volumes:
+        - emptyDir: {}
+          name: workspace-volume
         - downwardAPI:
             items:
             - fieldRef:


### PR DESCRIPTION
This PR fixes the nop pack's PipelineRun yaml by declaring "workspace-volume" in the volumes section (so that the volume can be mounted into tasks).