### PR TITLE
refactor: remove the need for jx v2 builder image used for next version

### DIFF
--- a/packs/C++/.lighthouse/jenkins-x/release.yaml
+++ b/packs/C++/.lighthouse/jenkins-x/release.yaml
@@ -16,18 +16,22 @@ spec:
           resources: {}
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --use-git-tag-only
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: tag-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION)
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/D/.lighthouse/jenkins-x/release.yaml
+++ b/packs/D/.lighthouse/jenkins-x/release.yaml
@@ -19,18 +19,22 @@ spec:
               memory: 1Gi
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --use-git-tag-only
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: tag-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION)
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/apps/.lighthouse/jenkins-x/release.yaml
+++ b/packs/apps/.lighthouse/jenkins-x/release.yaml
@@ -19,11 +19,22 @@ spec:
               memory: 600Mi
           workingDir: /workspace/source
         steps:
-        - command:
-          - jx step next-version --use-git-tag-only --tag
-          image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
           name: next-version
           resources: {}
+          script: |
+            #!/usr/bin/env bash
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/appserver/.lighthouse/jenkins-x/release.yaml
+++ b/packs/appserver/.lighthouse/jenkins-x/release.yaml
@@ -19,18 +19,22 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --filename pom.xml
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: tag-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION)
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/charts/.lighthouse/jenkins-x/release.yaml
+++ b/packs/charts/.lighthouse/jenkins-x/release.yaml
@@ -16,11 +16,22 @@ spec:
           resources: {}
           workingDir: /workspace/source
         steps:
-        - command:
-          - jx step next-version --use-git-tag-only --tag
-          image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
           name: next-version
           resources: {}
+          script: |
+            #!/usr/bin/env bash
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/csharp/.lighthouse/jenkins-x/release.yaml
+++ b/packs/csharp/.lighthouse/jenkins-x/release.yaml
@@ -19,12 +19,22 @@ spec:
               memory: 256Mi
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: tag-with-new-version
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
+          name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --use-git-tag-only --tag
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/custom-jenkins/.lighthouse/jenkins-x/release.yaml
+++ b/packs/custom-jenkins/.lighthouse/jenkins-x/release.yaml
@@ -19,11 +19,22 @@ spec:
               memory: 600Mi
           workingDir: /workspace/source
         steps:
-        - command:
-          - jx step next-version --use-git-tag-only --tag
-          image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
           name: next-version
           resources: {}
+          script: |
+            #!/usr/bin/env bash
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/cwp/.lighthouse/jenkins-x/release.yaml
+++ b/packs/cwp/.lighthouse/jenkins-x/release.yaml
@@ -19,18 +19,22 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --filename pom.xml
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: tag-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION)
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/docker-helm/.lighthouse/jenkins-x/release.yaml
+++ b/packs/docker-helm/.lighthouse/jenkins-x/release.yaml
@@ -19,12 +19,22 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: tag-with-new-version
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
+          name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --use-git-tag-only --tag
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/docker/.lighthouse/jenkins-x/release.yaml
+++ b/packs/docker/.lighthouse/jenkins-x/release.yaml
@@ -19,12 +19,16 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: tag-with-new-version
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
+          name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --use-git-tag-only --tag
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/git/.lighthouse/jenkins-x/release.yaml
+++ b/packs/git/.lighthouse/jenkins-x/release.yaml
@@ -19,12 +19,22 @@ spec:
               memory: 600Mi
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: tag-version
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
+          name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --use-git-tag-only --tag
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/go-cli/.lighthouse/jenkins-x/release.yaml
+++ b/packs/go-cli/.lighthouse/jenkins-x/release.yaml
@@ -25,24 +25,22 @@ spec:
           name: ""
           resources: {}
           workingDir: /home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME
-        - image: gcr.io/jenkinsxio/builder-go
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --use-git-tag-only
-        - image: gcr.io/jenkinsxio/builder-go
-          name: update-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION) --no-apply
-        - image: gcr.io/jenkinsxio/builder-go
-          name: tag-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION)
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/go-mongodb/.lighthouse/jenkins-x/release.yaml
+++ b/packs/go-mongodb/.lighthouse/jenkins-x/release.yaml
@@ -25,24 +25,22 @@ spec:
           name: ""
           resources: {}
           workingDir: /home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME
-        - image: gcr.io/jenkinsxio/builder-go
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --use-git-tag-only
-        - image: gcr.io/jenkinsxio/builder-go
-          name: update-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION) --no-apply
-        - image: gcr.io/jenkinsxio/builder-go
-          name: tag-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION)
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/go-plugin/.lighthouse/jenkins-x/release.yaml
+++ b/packs/go-plugin/.lighthouse/jenkins-x/release.yaml
@@ -16,24 +16,23 @@ spec:
           resources: {}
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio/builder-go
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --use-git-tag-only
-        - image: gcr.io/jenkinsxio/builder-go
-          name: update-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION) --no-apply
-        - image: gcr.io/jenkinsxio/builder-go
-          name: tag-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION)
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
+            
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/go/.lighthouse/jenkins-x/release.yaml
+++ b/packs/go/.lighthouse/jenkins-x/release.yaml
@@ -25,24 +25,22 @@ spec:
           name: ""
           resources: {}
           workingDir: /home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME
-        - image: gcr.io/jenkinsxio/builder-go
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --use-git-tag-only
-        - image: gcr.io/jenkinsxio/builder-go
-          name: update-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION) --no-apply
-        - image: gcr.io/jenkinsxio/builder-go
-          name: tag-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION)
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/gradle/.lighthouse/jenkins-x/release.yaml
+++ b/packs/gradle/.lighthouse/jenkins-x/release.yaml
@@ -19,18 +19,22 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --use-git-tag-only
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: tag-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION)
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/helm/.lighthouse/jenkins-x/release.yaml
+++ b/packs/helm/.lighthouse/jenkins-x/release.yaml
@@ -19,12 +19,22 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: tag-with-new-version
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
+          name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --use-git-tag-only --tag
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/javascript-ui-nginx/.lighthouse/jenkins-x/release.yaml
+++ b/packs/javascript-ui-nginx/.lighthouse/jenkins-x/release.yaml
@@ -19,17 +19,22 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --filename package.json
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: tag-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
             jx step tag --version $(cat VERSION)
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables

--- a/packs/javascript/.lighthouse/jenkins-x/release.yaml
+++ b/packs/javascript/.lighthouse/jenkins-x/release.yaml
@@ -19,24 +19,22 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio/builder-go
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --filename package.json
-        - image: gcr.io/jenkinsxio/builder-go
-          name: update-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION) --no-apply
-        - image: gcr.io/jenkinsxio/builder-go
-          name: tag-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION)
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/jenkins/.lighthouse/jenkins-x/release.yaml
+++ b/packs/jenkins/.lighthouse/jenkins-x/release.yaml
@@ -19,12 +19,22 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: tag-with-new-version
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
+          name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --use-git-tag-only --tag
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/jenkinsfilerunner/.lighthouse/jenkins-x/release.yaml
+++ b/packs/jenkinsfilerunner/.lighthouse/jenkins-x/release.yaml
@@ -16,11 +16,22 @@ spec:
           resources: {}
           workingDir: /workspace/source
         steps:
-        - command:
-          - jx step next-version --use-git-tag-only --tag
-          image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
           name: next-version
           resources: {}
+          script: |
+            #!/usr/bin/env bash
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/maven-java11/.lighthouse/jenkins-x/release.yaml
+++ b/packs/maven-java11/.lighthouse/jenkins-x/release.yaml
@@ -24,18 +24,22 @@ spec:
             name: release-gpg
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --filename pom.xml
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: tag-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION)
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/maven-node-ruby/.lighthouse/jenkins-x/release.yaml
+++ b/packs/maven-node-ruby/.lighthouse/jenkins-x/release.yaml
@@ -24,18 +24,22 @@ spec:
             name: release-gpg
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --filename pom.xml
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: tag-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION)
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/maven-quarkus/.lighthouse/jenkins-x/release.yaml
+++ b/packs/maven-quarkus/.lighthouse/jenkins-x/release.yaml
@@ -24,18 +24,22 @@ spec:
             name: release-gpg
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --filename pom.xml
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: tag-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION)
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/maven/.lighthouse/jenkins-x/release.yaml
+++ b/packs/maven/.lighthouse/jenkins-x/release.yaml
@@ -24,18 +24,22 @@ spec:
             name: release-gpg
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --filename pom.xml
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: tag-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION)
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/ml-python-gpu-service/.lighthouse/jenkins-x/release.yaml
+++ b/packs/ml-python-gpu-service/.lighthouse/jenkins-x/release.yaml
@@ -19,18 +19,22 @@ spec:
               memory: 1Gi
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: ""
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
+          name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --use-git-tag-only
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: ""
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION)
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/ml-python-service/.lighthouse/jenkins-x/release.yaml
+++ b/packs/ml-python-service/.lighthouse/jenkins-x/release.yaml
@@ -19,18 +19,22 @@ spec:
               memory: 4Gi
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: ""
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
+          name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --use-git-tag-only
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: ""
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION)
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/ml-python-training/.lighthouse/jenkins-x/release.yaml
+++ b/packs/ml-python-training/.lighthouse/jenkins-x/release.yaml
@@ -19,18 +19,22 @@ spec:
               memory: 4Gi
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: ""
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
+          name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --use-git-tag-only
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: ""
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION)
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/nop/.lighthouse/jenkins-x/release.yaml
+++ b/packs/nop/.lighthouse/jenkins-x/release.yaml
@@ -16,11 +16,22 @@ spec:
           resources: {}
           workingDir: /workspace/source
         steps:
-        - command:
-          - jx step next-version --use-git-tag-only --tag
-          image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
           name: next-version
           resources: {}
+          script: |
+            #!/usr/bin/env bash
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/php/.lighthouse/jenkins-x/release.yaml
+++ b/packs/php/.lighthouse/jenkins-x/release.yaml
@@ -19,12 +19,22 @@ spec:
               memory: 256Mi
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: tag-with-new-version
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
+          name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --use-git-tag-only --tag
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/python/.lighthouse/jenkins-x/release.yaml
+++ b/packs/python/.lighthouse/jenkins-x/release.yaml
@@ -19,18 +19,22 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --use-git-tag-only
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: tag-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION)
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/ruby/.lighthouse/jenkins-x/release.yaml
+++ b/packs/ruby/.lighthouse/jenkins-x/release.yaml
@@ -19,12 +19,22 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: tag-with-new-version
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
+          name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --use-git-tag-only --tag
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/rust/.lighthouse/jenkins-x/release.yaml
+++ b/packs/rust/.lighthouse/jenkins-x/release.yaml
@@ -19,18 +19,22 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --use-git-tag-only
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: tag-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION)
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/scala/.lighthouse/jenkins-x/release.yaml
+++ b/packs/scala/.lighthouse/jenkins-x/release.yaml
@@ -19,18 +19,22 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --use-git-tag-only
-        - image: gcr.io/jenkinsxio-labs-private/jxl:0.0.136
-          name: tag-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION)
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}

--- a/packs/typescript/.lighthouse/jenkins-x/release.yaml
+++ b/packs/typescript/.lighthouse/jenkins-x/release.yaml
@@ -19,24 +19,22 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio/builder-go
+        - image: gcr.io/jenkinsxio/jx-release-version:1.0.42
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env bash
-            jx step next-version --filename package.json
-        - image: gcr.io/jenkinsxio/builder-go
-          name: update-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION) --no-apply
-        - image: gcr.io/jenkinsxio/builder-go
-          name: tag-version
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            jx step tag --version $(cat VERSION)
+            VERSION=$(jx-release-version)
+            echo $VERSION > VERSION
+
+            if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
+            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git commit -a -m "release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push origin v$VERSION
         - image: gcr.io/jenkinsxio/jx-boot:3.0.738
           name: jx-variables
           resources: {}


### PR DESCRIPTION
I had a couple of options here but went with being a bit more explicit in the script rather than building more login in the next release version CLI.

This way it is clear to someone what is happening and can opt out of any part and move tagging to a different step etc if they wanted to