### PR TITLE
Only replace version for Chart, not dependencies

### DIFF
--- a/packs/helm/.lighthouse/jenkins-x/release.yaml
+++ b/packs/helm/.lighthouse/jenkins-x/release.yaml
@@ -41,7 +41,7 @@ spec:
             source /workspace/source/.jx/variables.sh
 
             if [ -d "/workspace/source/charts/$REPO_NAME" ]; then
-            sed -i -e "s/version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
+            sed -i -e "s/^version:.*/version: $VERSION/" ./charts/$REPO_NAME/Chart.yaml
             sed -i -e "s/repository:.*/repository: $DOCKER_REGISTRY\/$DOCKER_REGISTRY_ORG\/$APP_NAME/" ./charts/$REPO_NAME/values.yaml
             sed -i -e "s/tag:.*/tag: $VERSION/" ./charts/$REPO_NAME/values.yaml;
             else echo no charts; fi


### PR DESCRIPTION
This avoids replacing versions for dependency charts, as it matches "version" at the beginning of a line