### PR TITLE
fix: add path flag to build-cargo-install

### DIFF
--- a/packs/rust/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/rust/.lighthouse/jenkins-x/pullrequest.yaml
@@ -19,7 +19,7 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: gcr.io/jenkinsxio/jx-boot:3.1.153
+        - image: gcr.io/jenkinsxio/jx-boot:3.1.152
           name: jx-variables
           resources: {}
           script: |
@@ -36,7 +36,7 @@ spec:
           resources: {}
           script: |
             #!/bin/sh
-            cargo install
+            cargo install --path .
         - image: gcr.io/jenkinsxio/builder-rust:2.1.150-769
           name: build-copy-bin
           resources: {}

--- a/packs/rust/.lighthouse/jenkins-x/release.yaml
+++ b/packs/rust/.lighthouse/jenkins-x/release.yaml
@@ -42,7 +42,7 @@ spec:
           resources: {}
           script: |
             #!/bin/sh
-            cargo install
+            cargo install --path .
         - image: gcr.io/jenkinsxio/builder-rust:2.1.150-769
           name: build-copy-bin
           resources: {}


### PR DESCRIPTION
Cargo now requires a flag to explicitly install the working directory.
See https://github.com/jenkins-x-buildpacks/jenkins-x-classic/commit/ea31cc745e9603620893e2811d639954778847e2