### PR TITLE
fix: go build with jx variables

### DIFF
--- a/packs/go-plugin-multiarch/.lighthouse/jenkins-x/release.yaml
+++ b/packs/go-plugin-multiarch/.lighthouse/jenkins-x/release.yaml
@@ -32,7 +32,7 @@ spec:
           name: release-binary
           resources: {}
           script: |
-            #!/usr/bin/env sh
+            #!/usr/bin/env bash
             source .jx/variables.sh
             make release
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0

--- a/packs/go-plugin/.lighthouse/jenkins-x/release.yaml
+++ b/packs/go-plugin/.lighthouse/jenkins-x/release.yaml
@@ -32,7 +32,7 @@ spec:
           name: release-binary
           resources: {}
           script: |
-            #!/usr/bin/env sh
+            #!/usr/bin/env bash
             source .jx/variables.sh
             make release
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0


### PR DESCRIPTION
we can't use `sh` in the `golang` image, otherwise the `source .jx/variables.sh` cmd won't work:

```
Showing logs for build jenkins-x/jx-pipelines-visualizer/head #7 stage chart and container step-release-binary
/tekton/scripts/script-4-zd49r: 2: /tekton/scripts/script-4-zd49r: source: not found
```

switching to `bash` fixes the issue