### PR TITLE
fix: use sh for jx-release-version

### DIFF
--- a/packs/git/.lighthouse/jenkins-x/release.yaml
+++ b/packs/git/.lighthouse/jenkins-x/release.yaml
@@ -23,7 +23,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/C++/release.yaml
+++ b/tasks/C++/release.yaml
@@ -19,7 +19,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/D/release.yaml
+++ b/tasks/D/release.yaml
@@ -22,7 +22,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/apps/release.yaml
+++ b/tasks/apps/release.yaml
@@ -22,7 +22,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/appserver/release.yaml
+++ b/tasks/appserver/release.yaml
@@ -28,7 +28,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/charts/release.yaml
+++ b/tasks/charts/release.yaml
@@ -19,7 +19,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/csharp/release.yaml
+++ b/tasks/csharp/release.yaml
@@ -22,7 +22,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/custom-jenkins/release.yaml
+++ b/tasks/custom-jenkins/release.yaml
@@ -22,7 +22,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/cwp/release.yaml
+++ b/tasks/cwp/release.yaml
@@ -22,7 +22,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/docker-helm/release.yaml
+++ b/tasks/docker-helm/release.yaml
@@ -22,7 +22,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/docker/release.yaml
+++ b/tasks/docker/release.yaml
@@ -22,11 +22,8 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
-            git commit -a -m "chore: release $VERSION" --allow-empty
-            git tag -fa v$VERSION -m "Release version $VERSION"
-            git push origin v$VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables
           resources: {}

--- a/tasks/go-cli/release.yaml
+++ b/tasks/go-cli/release.yaml
@@ -22,7 +22,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/go-mongodb/release.yaml
+++ b/tasks/go-mongodb/release.yaml
@@ -22,7 +22,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/go-plugin-multiarch/release.yaml
+++ b/tasks/go-plugin-multiarch/release.yaml
@@ -19,7 +19,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/go-plugin/release.yaml
+++ b/tasks/go-plugin/release.yaml
@@ -19,7 +19,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/go/release.yaml
+++ b/tasks/go/release.yaml
@@ -22,7 +22,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/gradle/release.yaml
+++ b/tasks/gradle/release.yaml
@@ -22,7 +22,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/helm/release.yaml
+++ b/tasks/helm/release.yaml
@@ -22,7 +22,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/javascript-ui-nginx/release.yaml
+++ b/tasks/javascript-ui-nginx/release.yaml
@@ -28,9 +28,8 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
-            jx step tag --version $(cat VERSION)
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables
           resources: {}

--- a/tasks/javascript/release.yaml
+++ b/tasks/javascript/release.yaml
@@ -28,7 +28,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/jenkins/release.yaml
+++ b/tasks/jenkins/release.yaml
@@ -28,7 +28,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/jenkinsfilerunner/release.yaml
+++ b/tasks/jenkinsfilerunner/release.yaml
@@ -19,7 +19,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/maven-java11/release.yaml
+++ b/tasks/maven-java11/release.yaml
@@ -32,7 +32,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/maven-node-ruby/release.yaml
+++ b/tasks/maven-node-ruby/release.yaml
@@ -33,7 +33,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/maven-quarkus/release.yaml
+++ b/tasks/maven-quarkus/release.yaml
@@ -32,7 +32,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/maven/release.yaml
+++ b/tasks/maven/release.yaml
@@ -33,7 +33,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/ml-python-gpu-service/release.yaml
+++ b/tasks/ml-python-gpu-service/release.yaml
@@ -22,7 +22,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/ml-python-service/release.yaml
+++ b/tasks/ml-python-service/release.yaml
@@ -22,7 +22,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/ml-python-training/release.yaml
+++ b/tasks/ml-python-training/release.yaml
@@ -22,7 +22,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/nop/release.yaml
+++ b/tasks/nop/release.yaml
@@ -19,7 +19,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/php/release.yaml
+++ b/tasks/php/release.yaml
@@ -22,7 +22,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/python/release.yaml
+++ b/tasks/python/release.yaml
@@ -22,7 +22,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/ruby/release.yaml
+++ b/tasks/ruby/release.yaml
@@ -22,7 +22,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/rust/release.yaml
+++ b/tasks/rust/release.yaml
@@ -22,7 +22,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/scala/release.yaml
+++ b/tasks/scala/release.yaml
@@ -22,7 +22,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables

--- a/tasks/typescript/release.yaml
+++ b/tasks/typescript/release.yaml
@@ -28,7 +28,7 @@ spec:
           name: next-version
           resources: {}
           script: |
-            #!/usr/bin/env bash
+            #!/usr/bin/env sh
             jx-release-version > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.1.215
           name: jx-variables


### PR DESCRIPTION
the current docker image for https://github.com/jenkins-x-plugins/jx-release-version is very big (> 2 GB), for a very small binary...
I'm going to change the base image to something smaller (alpine), which doesn't have bash by default.
so let's switch the shell used to sh instead of bash (we don't need bash here anyway)

also fixing some integrations which are broken (executing commands which are not in this docker image...)