### PR TITLE
fix: add a verify pod chart

### DIFF
--- a/helm/preview/helmfile.yaml
+++ b/helm/preview/helmfile.yaml
@@ -2,7 +2,13 @@ environments:
   default:
     values:
     - jx-values.yaml
+repositories:
+- name: jx3
+  url: https://storage.googleapis.com/jenkinsxio/charts
 releases:
+- chart: jx3/jx-verify
+  name: jx-verify
+  namespace: '{{ requiredEnv "PREVIEW_NAMESPACE" }}'
 - chart: '../charts/{{ requiredEnv "APP_NAME" }}'
   name: preview
   wait: true


### PR DESCRIPTION
to ensure we eagerly delete preview pods which have not yet had their workload identity repicated