### PR TITLE
chore: do not change version for PRs

### DIFF
--- a/tasks/maven-java11/pullrequest.yaml
+++ b/tasks/maven-java11/pullrequest.yaml
@@ -35,7 +35,7 @@ spec:
           script: |
             #!/bin/sh
             source .jx/variables.sh
-            mvn --no-transfer-progress versions:set -DnewVersion=$VERSION
+            echo "not changing version for SNAPSHOT"
         - image: maven:3.6-openjdk-11
           name: build-mvn-install
           resources: {}

--- a/tasks/maven-node-ruby/pullrequest.yaml
+++ b/tasks/maven-node-ruby/pullrequest.yaml
@@ -36,7 +36,7 @@ spec:
           script: |
             #!/bin/sh
             source .jx/variables.sh
-            mvn --no-transfer-progress versions:set -DnewVersion=$VERSION
+            echo "not changing version for SNAPSHOT"
         - image: maven:3.6-openjdk-8
           name: build-mvn-install
           resources: {}

--- a/tasks/maven-quarkus/pullrequest.yaml
+++ b/tasks/maven-quarkus/pullrequest.yaml
@@ -35,7 +35,7 @@ spec:
           script: |
             #!/bin/sh
             source .jx/variables.sh
-            mvn --no-transfer-progress versions:set -DnewVersion=$VERSION
+            echo "not changing version for SNAPSHOT"
         - image: gcr.io/jenkinsxio/builder-maven-graalvm:2.1.150-769
           name: build-mvn-install
           resources: {}


### PR DESCRIPTION
we should not modify the maven pom.xml on PR pipelines as we need to keep the SNAPSHOT version