### PR TITLE
fix: add check-registry step

### DIFF
--- a/packs/C++/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/C++/.lighthouse/jenkins-x/pullrequest.yaml
@@ -25,6 +25,8 @@ spec:
           resources: {}
         - name: build-make
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-jx-preview

--- a/packs/C++/.lighthouse/jenkins-x/release.yaml
+++ b/packs/C++/.lighthouse/jenkins-x/release.yaml
@@ -27,6 +27,8 @@ spec:
           resources: {}
         - name: build-make
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/packs/D/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/D/.lighthouse/jenkins-x/pullrequest.yaml
@@ -26,6 +26,8 @@ spec:
           resources: {}
         - name: build-dub-build
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-jx-preview

--- a/packs/D/.lighthouse/jenkins-x/release.yaml
+++ b/packs/D/.lighthouse/jenkins-x/release.yaml
@@ -28,6 +28,8 @@ spec:
           resources: {}
         - name: build-dub-build
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/packs/appserver/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/appserver/.lighthouse/jenkins-x/pullrequest.yaml
@@ -34,6 +34,8 @@ spec:
           resources: {}
         - name: build-mvn-install
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-jx-preview

--- a/packs/appserver/.lighthouse/jenkins-x/release.yaml
+++ b/packs/appserver/.lighthouse/jenkins-x/release.yaml
@@ -34,6 +34,8 @@ spec:
           resources: {}
         - name: build-mvn-deploy
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/packs/csharp/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/csharp/.lighthouse/jenkins-x/pullrequest.yaml
@@ -24,6 +24,8 @@ spec:
           resources: {}
         - name: jx-variables
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-jx-preview

--- a/packs/csharp/.lighthouse/jenkins-x/release.yaml
+++ b/packs/csharp/.lighthouse/jenkins-x/release.yaml
@@ -26,6 +26,8 @@ spec:
           resources: {}
         - name: jx-variables
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/packs/cwp/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/cwp/.lighthouse/jenkins-x/pullrequest.yaml
@@ -34,6 +34,8 @@ spec:
           resources: {}
         - name: build-mvn-install
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-jx-preview

--- a/packs/cwp/.lighthouse/jenkins-x/release.yaml
+++ b/packs/cwp/.lighthouse/jenkins-x/release.yaml
@@ -28,6 +28,8 @@ spec:
           resources: {}
         - name: build-mvn-deploy
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/packs/docker-helm/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/docker-helm/.lighthouse/jenkins-x/pullrequest.yaml
@@ -24,6 +24,8 @@ spec:
           resources: {}
         - name: jx-variables
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
   podTemplate: {}

--- a/packs/docker-helm/.lighthouse/jenkins-x/release.yaml
+++ b/packs/docker-helm/.lighthouse/jenkins-x/release.yaml
@@ -26,6 +26,8 @@ spec:
           resources: {}
         - name: jx-variables
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/packs/docker/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/docker/.lighthouse/jenkins-x/pullrequest.yaml
@@ -24,6 +24,8 @@ spec:
           resources: {}
         - name: jx-variables
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
   podTemplate: {}

--- a/packs/docker/.lighthouse/jenkins-x/release.yaml
+++ b/packs/docker/.lighthouse/jenkins-x/release.yaml
@@ -26,6 +26,8 @@ spec:
           resources: {}
         - name: jx-variables
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/packs/go-cli/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/go-cli/.lighthouse/jenkins-x/pullrequest.yaml
@@ -28,6 +28,8 @@ spec:
           resources: {}
         - name: build-make-test
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
   podTemplate: {}

--- a/packs/go-cli/.lighthouse/jenkins-x/release.yaml
+++ b/packs/go-cli/.lighthouse/jenkins-x/release.yaml
@@ -28,6 +28,8 @@ spec:
           resources: {}
         - name: build-make-build
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
   podTemplate: {}

--- a/packs/go-mongodb/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/go-mongodb/.lighthouse/jenkins-x/pullrequest.yaml
@@ -26,6 +26,8 @@ spec:
           resources: {}
         - name: build-make-linux
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-jx-preview

--- a/packs/go-mongodb/.lighthouse/jenkins-x/release.yaml
+++ b/packs/go-mongodb/.lighthouse/jenkins-x/release.yaml
@@ -28,6 +28,8 @@ spec:
           resources: {}
         - name: build-make-build
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/packs/go-plugin-multiarch/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/go-plugin-multiarch/.lighthouse/jenkins-x/pullrequest.yaml
@@ -28,6 +28,8 @@ spec:
           resources: {}
         - name: build-make-test
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
   podTemplate: {}

--- a/packs/go-plugin/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/go-plugin/.lighthouse/jenkins-x/pullrequest.yaml
@@ -28,6 +28,8 @@ spec:
           resources: {}
         - name: build-make-test
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
   podTemplate: {}

--- a/packs/go/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/go/.lighthouse/jenkins-x/pullrequest.yaml
@@ -26,6 +26,8 @@ spec:
           resources: {}
         - name: build-make-linux
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-jx-preview

--- a/packs/go/.lighthouse/jenkins-x/release.yaml
+++ b/packs/go/.lighthouse/jenkins-x/release.yaml
@@ -28,6 +28,8 @@ spec:
           resources: {}
         - name: build-make-build
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/packs/gradle/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/gradle/.lighthouse/jenkins-x/pullrequest.yaml
@@ -26,6 +26,8 @@ spec:
           resources: {}
         - name: build-gradle-build
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-jx-preview

--- a/packs/gradle/.lighthouse/jenkins-x/release.yaml
+++ b/packs/gradle/.lighthouse/jenkins-x/release.yaml
@@ -28,6 +28,8 @@ spec:
           resources: {}
         - name: build-gradle-build
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/packs/javascript-ui-nginx/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/javascript-ui-nginx/.lighthouse/jenkins-x/pullrequest.yaml
@@ -30,6 +30,8 @@ spec:
           resources: {}
         - name: build-ui-build
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-jx-preview

--- a/packs/javascript-ui-nginx/.lighthouse/jenkins-x/release.yaml
+++ b/packs/javascript-ui-nginx/.lighthouse/jenkins-x/release.yaml
@@ -38,6 +38,8 @@ spec:
           resources: {}
         - name: build-ui-build
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/packs/javascript/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/javascript/.lighthouse/jenkins-x/pullrequest.yaml
@@ -28,6 +28,8 @@ spec:
           resources: {}
         - name: build-npm-test
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-jx-preview

--- a/packs/javascript/.lighthouse/jenkins-x/release.yaml
+++ b/packs/javascript/.lighthouse/jenkins-x/release.yaml
@@ -36,6 +36,8 @@ spec:
           resources: {}
         - name: build-npm-test
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/packs/jenkins/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/jenkins/.lighthouse/jenkins-x/pullrequest.yaml
@@ -30,6 +30,8 @@ spec:
           resources: {}
         - name: jx-variables
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
   podTemplate: {}

--- a/packs/jenkins/.lighthouse/jenkins-x/release.yaml
+++ b/packs/jenkins/.lighthouse/jenkins-x/release.yaml
@@ -32,6 +32,8 @@ spec:
           resources: {}
         - name: jx-variables
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/packs/maven-java11/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/maven-java11/.lighthouse/jenkins-x/pullrequest.yaml
@@ -33,6 +33,8 @@ spec:
           resources: {}
         - name: build-mvn-install
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-jx-preview

--- a/packs/maven-java11/.lighthouse/jenkins-x/release.yaml
+++ b/packs/maven-java11/.lighthouse/jenkins-x/release.yaml
@@ -38,6 +38,8 @@ spec:
           resources: {}
         - name: build-mvn-deploy
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/packs/maven-node-ruby/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/maven-node-ruby/.lighthouse/jenkins-x/pullrequest.yaml
@@ -34,6 +34,8 @@ spec:
           resources: {}
         - name: build-mvn-install
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-jx-preview

--- a/packs/maven-node-ruby/.lighthouse/jenkins-x/release.yaml
+++ b/packs/maven-node-ruby/.lighthouse/jenkins-x/release.yaml
@@ -39,6 +39,8 @@ spec:
           resources: {}
         - name: build-mvn-deploy
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/packs/maven-quarkus/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/maven-quarkus/.lighthouse/jenkins-x/pullrequest.yaml
@@ -33,6 +33,8 @@ spec:
           resources: {}
         - name: build-mvn-install
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-jx-preview

--- a/packs/maven-quarkus/.lighthouse/jenkins-x/release.yaml
+++ b/packs/maven-quarkus/.lighthouse/jenkins-x/release.yaml
@@ -38,6 +38,8 @@ spec:
           resources: {}
         - name: build-mvn-deploy
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/packs/maven/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/maven/.lighthouse/jenkins-x/pullrequest.yaml
@@ -34,6 +34,8 @@ spec:
           resources: {}
         - name: build-mvn-install
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-jx-preview

--- a/packs/maven/.lighthouse/jenkins-x/release.yaml
+++ b/packs/maven/.lighthouse/jenkins-x/release.yaml
@@ -39,6 +39,8 @@ spec:
           resources: {}
         - name: build-mvn-deploy
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/packs/ml-python-gpu-service/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/ml-python-gpu-service/.lighthouse/jenkins-x/pullrequest.yaml
@@ -30,6 +30,8 @@ spec:
           resources: {}
         - name: build-testing
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-jx-preview

--- a/packs/ml-python-gpu-service/.lighthouse/jenkins-x/release.yaml
+++ b/packs/ml-python-gpu-service/.lighthouse/jenkins-x/release.yaml
@@ -32,6 +32,8 @@ spec:
           resources: {}
         - name: build-testing
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/packs/ml-python-service/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/ml-python-service/.lighthouse/jenkins-x/pullrequest.yaml
@@ -30,6 +30,8 @@ spec:
           resources: {}
         - name: build-testing
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-jx-preview

--- a/packs/ml-python-service/.lighthouse/jenkins-x/release.yaml
+++ b/packs/ml-python-service/.lighthouse/jenkins-x/release.yaml
@@ -32,6 +32,8 @@ spec:
           resources: {}
         - name: build-testing
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/packs/php/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/php/.lighthouse/jenkins-x/pullrequest.yaml
@@ -24,6 +24,8 @@ spec:
           resources: {}
         - name: jx-variables
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-jx-preview

--- a/packs/php/.lighthouse/jenkins-x/release.yaml
+++ b/packs/php/.lighthouse/jenkins-x/release.yaml
@@ -26,6 +26,8 @@ spec:
           resources: {}
         - name: jx-variables
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/packs/python/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/python/.lighthouse/jenkins-x/pullrequest.yaml
@@ -26,6 +26,8 @@ spec:
           resources: {}
         - name: build-python-unittest
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-jx-preview

--- a/packs/python/.lighthouse/jenkins-x/release.yaml
+++ b/packs/python/.lighthouse/jenkins-x/release.yaml
@@ -28,6 +28,8 @@ spec:
           resources: {}
         - name: build-python-unittest
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/packs/ruby/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/ruby/.lighthouse/jenkins-x/pullrequest.yaml
@@ -24,6 +24,8 @@ spec:
           resources: {}
         - name: jx-variables
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-jx-preview

--- a/packs/ruby/.lighthouse/jenkins-x/release.yaml
+++ b/packs/ruby/.lighthouse/jenkins-x/release.yaml
@@ -26,6 +26,8 @@ spec:
           resources: {}
         - name: jx-variables
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/packs/rust/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/rust/.lighthouse/jenkins-x/pullrequest.yaml
@@ -26,6 +26,8 @@ spec:
           resources: {}
         - name: build-cargo-install
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-jx-preview

--- a/packs/rust/.lighthouse/jenkins-x/release.yaml
+++ b/packs/rust/.lighthouse/jenkins-x/release.yaml
@@ -28,6 +28,8 @@ spec:
           resources: {}
         - name: build-cargo-install
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/packs/scala/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/scala/.lighthouse/jenkins-x/pullrequest.yaml
@@ -26,6 +26,8 @@ spec:
           resources: {}
         - name: build-sbt-assembly
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-jx-preview

--- a/packs/scala/.lighthouse/jenkins-x/release.yaml
+++ b/packs/scala/.lighthouse/jenkins-x/release.yaml
@@ -28,6 +28,8 @@ spec:
           resources: {}
         - name: build-sbt-assembly
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/packs/typescript/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/typescript/.lighthouse/jenkins-x/pullrequest.yaml
@@ -28,6 +28,8 @@ spec:
           resources: {}
         - name: build-npm-test
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-jx-preview

--- a/packs/typescript/.lighthouse/jenkins-x/release.yaml
+++ b/packs/typescript/.lighthouse/jenkins-x/release.yaml
@@ -36,6 +36,8 @@ spec:
           resources: {}
         - name: build-npm-test
           resources: {}
+        - name: check-registry
+          resources: {}
         - name: build-container-build
           resources: {}
         - name: promote-changelog

--- a/tasks/C++/pullrequest.yaml
+++ b/tasks/C++/pullrequest.yaml
@@ -33,6 +33,8 @@ spec:
           script: |
             #!/bin/sh
             make
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/C++/release.yaml
+++ b/tasks/C++/release.yaml
@@ -39,6 +39,8 @@ spec:
           script: |
             #!/bin/sh
             make
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/D/pullrequest.yaml
+++ b/tasks/D/pullrequest.yaml
@@ -30,6 +30,8 @@ spec:
           script: |
             #!/bin/sh
             dub build --build=release
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/D/release.yaml
+++ b/tasks/D/release.yaml
@@ -36,6 +36,8 @@ spec:
           script: |
             #!/bin/sh
             dub build --build=release
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/appserver/pullrequest.yaml
+++ b/tasks/appserver/pullrequest.yaml
@@ -43,6 +43,8 @@ spec:
           script: |
             #!/bin/sh
             mvn --no-transfer-progress install
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/appserver/release.yaml
+++ b/tasks/appserver/release.yaml
@@ -42,6 +42,8 @@ spec:
           script: |
             #!/bin/sh
             mvn --no-transfer-progress clean deploy
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/csharp/pullrequest.yaml
+++ b/tasks/csharp/pullrequest.yaml
@@ -24,6 +24,8 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/csharp/release.yaml
+++ b/tasks/csharp/release.yaml
@@ -30,6 +30,8 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/cwp/pullrequest.yaml
+++ b/tasks/cwp/pullrequest.yaml
@@ -43,6 +43,8 @@ spec:
           script: |
             #!/bin/sh
             mvn --no-transfer-progress install
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/docker-helm/pullrequest.yaml
+++ b/tasks/docker-helm/pullrequest.yaml
@@ -24,6 +24,8 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/docker-helm/release.yaml
+++ b/tasks/docker-helm/release.yaml
@@ -30,6 +30,8 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/docker/pullrequest.yaml
+++ b/tasks/docker/pullrequest.yaml
@@ -24,6 +24,8 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/docker/release.yaml
+++ b/tasks/docker/release.yaml
@@ -30,6 +30,8 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/go-cli/pullrequest.yaml
+++ b/tasks/go-cli/pullrequest.yaml
@@ -36,6 +36,8 @@ spec:
           script: |
             #!/bin/sh
             make test
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/go-cli/release.yaml
+++ b/tasks/go-cli/release.yaml
@@ -36,6 +36,8 @@ spec:
           script: |
             #!/bin/sh
             make release
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/go-mongodb/pullrequest.yaml
+++ b/tasks/go-mongodb/pullrequest.yaml
@@ -30,6 +30,8 @@ spec:
           script: |
             #!/bin/sh
             make linux
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/go-mongodb/release.yaml
+++ b/tasks/go-mongodb/release.yaml
@@ -36,6 +36,8 @@ spec:
           script: |
             #!/bin/sh
             make build
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/go-plugin-multiarch/pullrequest.yaml
+++ b/tasks/go-plugin-multiarch/pullrequest.yaml
@@ -36,6 +36,8 @@ spec:
           script: |
             #!/bin/sh
             make test
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/go-plugin/pullrequest.yaml
+++ b/tasks/go-plugin/pullrequest.yaml
@@ -36,6 +36,8 @@ spec:
           script: |
             #!/bin/sh
             make test
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/go/pullrequest.yaml
+++ b/tasks/go/pullrequest.yaml
@@ -30,6 +30,8 @@ spec:
           script: |
             #!/bin/sh
             make linux
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/go/release.yaml
+++ b/tasks/go/release.yaml
@@ -36,6 +36,8 @@ spec:
           script: |
             #!/bin/sh
             make build
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/gradle/pullrequest.yaml
+++ b/tasks/gradle/pullrequest.yaml
@@ -30,6 +30,8 @@ spec:
           script: |
             #!/bin/sh
             gradle clean build
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/gradle/release.yaml
+++ b/tasks/gradle/release.yaml
@@ -36,6 +36,8 @@ spec:
           script: |
             #!/bin/sh
             gradle clean build
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/javascript-ui-nginx/pullrequest.yaml
+++ b/tasks/javascript-ui-nginx/pullrequest.yaml
@@ -42,6 +42,8 @@ spec:
           script: |
             #!/bin/sh
             npm run build
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/javascript-ui-nginx/release.yaml
+++ b/tasks/javascript-ui-nginx/release.yaml
@@ -54,6 +54,8 @@ spec:
           script: |
             #!/bin/sh
             npm run build
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/javascript/pullrequest.yaml
+++ b/tasks/javascript/pullrequest.yaml
@@ -36,6 +36,8 @@ spec:
           script: |
             #!/bin/sh
             CI=true DISPLAY=:99 npm test
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/javascript/release.yaml
+++ b/tasks/javascript/release.yaml
@@ -48,6 +48,8 @@ spec:
           script: |
             #!/bin/sh
             CI=true DISPLAY=:99 npm test
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/jenkins/pullrequest.yaml
+++ b/tasks/jenkins/pullrequest.yaml
@@ -30,6 +30,8 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/jenkins/release.yaml
+++ b/tasks/jenkins/release.yaml
@@ -36,6 +36,8 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/maven-java11/pullrequest.yaml
+++ b/tasks/maven-java11/pullrequest.yaml
@@ -42,6 +42,8 @@ spec:
           script: |
             #!/bin/sh
             mvn --no-transfer-progress install
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/maven-java11/release.yaml
+++ b/tasks/maven-java11/release.yaml
@@ -52,6 +52,8 @@ spec:
             mvn versions:set -DnewVersion=$VERSION
 
             mvn --no-transfer-progress clean deploy
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/maven-node-ruby/pullrequest.yaml
+++ b/tasks/maven-node-ruby/pullrequest.yaml
@@ -43,6 +43,8 @@ spec:
           script: |
             #!/bin/sh
             mvn --no-transfer-progress install
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/maven-node-ruby/release.yaml
+++ b/tasks/maven-node-ruby/release.yaml
@@ -53,6 +53,8 @@ spec:
             mvn versions:set -DnewVersion=$VERSION
 
             mvn --no-transfer-progress clean deploy
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/maven-quarkus/pullrequest.yaml
+++ b/tasks/maven-quarkus/pullrequest.yaml
@@ -42,6 +42,8 @@ spec:
           script: |
             #!/bin/sh
             mvn --no-transfer-progress install
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/maven-quarkus/release.yaml
+++ b/tasks/maven-quarkus/release.yaml
@@ -52,6 +52,8 @@ spec:
             mvn versions:set -DnewVersion=$VERSION
 
             mvn --no-transfer-progress clean deploy
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/maven/pullrequest.yaml
+++ b/tasks/maven/pullrequest.yaml
@@ -43,6 +43,8 @@ spec:
           script: |
             #!/bin/sh
             mvn --no-transfer-progress install
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/maven/release.yaml
+++ b/tasks/maven/release.yaml
@@ -53,6 +53,8 @@ spec:
             mvn versions:set -DnewVersion=$VERSION
 
             mvn --no-transfer-progress clean deploy
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/ml-python-gpu-service/pullrequest.yaml
+++ b/tasks/ml-python-gpu-service/pullrequest.yaml
@@ -46,6 +46,8 @@ spec:
             #!/bin/sh
             source /root/.bashrc
             pytest
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/ml-python-gpu-service/release.yaml
+++ b/tasks/ml-python-gpu-service/release.yaml
@@ -51,6 +51,8 @@ spec:
             #!/bin/sh
             source /root/.bashrc
             pytest
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/ml-python-service/pullrequest.yaml
+++ b/tasks/ml-python-service/pullrequest.yaml
@@ -46,6 +46,8 @@ spec:
             #!/bin/sh
             source /root/.bashrc
             pytest
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/ml-python-service/release.yaml
+++ b/tasks/ml-python-service/release.yaml
@@ -51,6 +51,8 @@ spec:
             #!/bin/sh
             source /root/.bashrc
             pytest
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/php/pullrequest.yaml
+++ b/tasks/php/pullrequest.yaml
@@ -24,6 +24,8 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/php/release.yaml
+++ b/tasks/php/release.yaml
@@ -30,6 +30,8 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/python/pullrequest.yaml
+++ b/tasks/python/pullrequest.yaml
@@ -30,6 +30,8 @@ spec:
           script: |
             #!/bin/sh
             python -m unittest
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/python/release.yaml
+++ b/tasks/python/release.yaml
@@ -36,6 +36,8 @@ spec:
           script: |
             #!/bin/sh
             python -m unittest
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/ruby/pullrequest.yaml
+++ b/tasks/ruby/pullrequest.yaml
@@ -24,6 +24,8 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/ruby/release.yaml
+++ b/tasks/ruby/release.yaml
@@ -30,6 +30,8 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/rust/pullrequest.yaml
+++ b/tasks/rust/pullrequest.yaml
@@ -30,6 +30,8 @@ spec:
           script: |
             #!/bin/sh
             cargo install --path .
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/rust/release.yaml
+++ b/tasks/rust/release.yaml
@@ -36,6 +36,8 @@ spec:
           script: |
             #!/bin/sh
             cargo install --path .
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/typescript/pullrequest.yaml
+++ b/tasks/typescript/pullrequest.yaml
@@ -36,6 +36,8 @@ spec:
           script: |
             #!/bin/sh
             CI=true DISPLAY=:99 npm test
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}

--- a/tasks/typescript/release.yaml
+++ b/tasks/typescript/release.yaml
@@ -48,6 +48,8 @@ spec:
           script: |
             #!/bin/sh
             CI=true DISPLAY=:99 npm test
+        - image: gcr.io/jenkinsxio/jx-registry:0.0.3
+          name: check-registry
         - image: gcr.io/kaniko-project/executor:debug-v1.3.0
           name: build-container-build
           resources: {}


### PR DESCRIPTION
to verify the container registry exists prior to building the image. This is only really required so far on ECR