### PR TITLE
Adding default name to container port inside a Deployment

### DIFF
--- a/helm/charts/templates/deployment.yaml
+++ b/helm/charts/templates/deployment.yaml
@@ -46,7 +46,8 @@ spec:
         envFrom:
 {{ toYaml .Values.envFrom | indent 10 }}
         ports:
-        - containerPort: {{ .Values.service.internalPort }}
+        - name: http
+          containerPort: {{ .Values.service.internalPort }}
         livenessProbe:
           httpGet:
             path: {{ .Values.livenessProbe.probePath | default .Values.probePath }}


### PR DESCRIPTION
This is needed by Prometheus to scrape the pods of a deployment.
This simplifies the configuration of a ServiceMonitor when using Prometheus: 

For example: 

```
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: fmtok8s-servicemonitor 
  labels:
    release: myprometheus
spec:
  selector:
    matchLabels:
      draft: draft-app
  namespaceSelector:
    matchNames:
      - default
  jobLabel: service-stats
  endpoints:
  - path: /actuator/prometheus
    **targetPort: http**
    interval: 15s
```

Where the target port is the name added in this PR. 