### PR TITLE
fix: use 80 as internal port for th PHP buildpack

### DIFF
--- a/packs/php/charts/values.yaml
+++ b/packs/php/charts/values.yaml
@@ -48,7 +48,7 @@ service:
   name: REPLACE_ME_APP_NAME
   type: ClusterIP
   externalPort: 80
-  internalPort: 8080
+  internalPort: 80
   annotations: {}
 resources:
   limits:


### PR DESCRIPTION
Fixes https://github.com/jenkins-x/jx3-pipeline-catalog/issues/460