### PR TITLE
feat: lets create and push git tags asap in the pipeline to avoid con…

### DIFF
--- a/packs/git/.lighthouse/jenkins-x/release.yaml
+++ b/packs/git/.lighthouse/jenkins-x/release.yaml
@@ -24,7 +24,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/C++/release.yaml
+++ b/tasks/C++/release.yaml
@@ -20,7 +20,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/D/release.yaml
+++ b/tasks/D/release.yaml
@@ -23,7 +23,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/apps/release.yaml
+++ b/tasks/apps/release.yaml
@@ -23,7 +23,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/appserver/release.yaml
+++ b/tasks/appserver/release.yaml
@@ -31,7 +31,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/charts/release.yaml
+++ b/tasks/charts/release.yaml
@@ -20,7 +20,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/csharp/release.yaml
+++ b/tasks/csharp/release.yaml
@@ -23,7 +23,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/custom-jenkins/release.yaml
+++ b/tasks/custom-jenkins/release.yaml
@@ -23,7 +23,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/cwp/release.yaml
+++ b/tasks/cwp/release.yaml
@@ -31,7 +31,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/docker-helm/release.yaml
+++ b/tasks/docker-helm/release.yaml
@@ -23,7 +23,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/docker/release.yaml
+++ b/tasks/docker/release.yaml
@@ -23,7 +23,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/flutter/release.yaml
+++ b/tasks/flutter/release.yaml
@@ -29,7 +29,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/go-cli/release.yaml
+++ b/tasks/go-cli/release.yaml
@@ -23,7 +23,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/go-mongodb/release.yaml
+++ b/tasks/go-mongodb/release.yaml
@@ -23,7 +23,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/go-plugin-multiarch/release.yaml
+++ b/tasks/go-plugin-multiarch/release.yaml
@@ -20,7 +20,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/go-plugin/release.yaml
+++ b/tasks/go-plugin/release.yaml
@@ -20,7 +20,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/go/release.yaml
+++ b/tasks/go/release.yaml
@@ -23,7 +23,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/gradle/release.yaml
+++ b/tasks/gradle/release.yaml
@@ -23,7 +23,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/helm/release.yaml
+++ b/tasks/helm/release.yaml
@@ -23,7 +23,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/javascript-ui-nginx/release.yaml
+++ b/tasks/javascript-ui-nginx/release.yaml
@@ -29,7 +29,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/javascript/release.yaml
+++ b/tasks/javascript/release.yaml
@@ -29,7 +29,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/jenkins/release.yaml
+++ b/tasks/jenkins/release.yaml
@@ -31,7 +31,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/jenkinsfilerunner/release.yaml
+++ b/tasks/jenkinsfilerunner/release.yaml
@@ -20,7 +20,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/maven-java11/release.yaml
+++ b/tasks/maven-java11/release.yaml
@@ -35,7 +35,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/maven-node-ruby/release.yaml
+++ b/tasks/maven-node-ruby/release.yaml
@@ -36,7 +36,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/maven-quarkus/release.yaml
+++ b/tasks/maven-quarkus/release.yaml
@@ -35,7 +35,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/maven/release.yaml
+++ b/tasks/maven/release.yaml
@@ -36,7 +36,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/ml-python-gpu-service/release.yaml
+++ b/tasks/ml-python-gpu-service/release.yaml
@@ -23,7 +23,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/ml-python-service/release.yaml
+++ b/tasks/ml-python-service/release.yaml
@@ -23,7 +23,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/ml-python-training/release.yaml
+++ b/tasks/ml-python-training/release.yaml
@@ -23,7 +23,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/nop/release.yaml
+++ b/tasks/nop/release.yaml
@@ -20,7 +20,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/php/release.yaml
+++ b/tasks/php/release.yaml
@@ -23,7 +23,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/python/release.yaml
+++ b/tasks/python/release.yaml
@@ -23,7 +23,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/ruby/release.yaml
+++ b/tasks/ruby/release.yaml
@@ -23,7 +23,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/rust/release.yaml
+++ b/tasks/rust/release.yaml
@@ -23,7 +23,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/scala/release.yaml
+++ b/tasks/scala/release.yaml
@@ -30,7 +30,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}

--- a/tasks/typescript/release.yaml
+++ b/tasks/typescript/release.yaml
@@ -29,7 +29,18 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx-release-version > VERSION
+            jx-release-version --tag > VERSION
+          env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: password
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                name: tekton-git
+                key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.15
           name: jx-variables
           resources: {}


### PR DESCRIPTION
…flicts

this prevents some issues we have seen where a release pipeline can fail before it has pushed the tag, which means subsequent pipeline runs can use the same version which can cause conflicts if the helm package was published in the previous failed run.