### PR TITLE
chore: add a prefix to the env release pipeline name

### DIFF
--- a/environment/.lighthouse/jenkins-x/triggers.yaml
+++ b/environment/.lighthouse/jenkins-x/triggers.yaml
@@ -40,8 +40,8 @@ spec:
 
 
   postsubmits:
-  - name: release
-    context: "release"
+  - name: bootjob
+    context: "bootjob"
     source: "release.yaml"
     branches:
     - ^main$


### PR DESCRIPTION
So we can easily distinguish app release jobs/pods from the env release jobs/pods.