### PR TITLE
feat: restart lighthouse pods on pipeline catalog release

### DIFF
--- a/.lighthouse/jenkins-x/promote.sh
+++ b/.lighthouse/jenkins-x/promote.sh
@@ -1,3 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
-echo "promoting"
+echo "promoting, restart lighthouse pods"
+kubectl get pods -n jx | grep lighthouse- | awk '{print $1}' | xargs kubectl delete pod -n jx


### PR DESCRIPTION
Ensure the last pipeline versions are taken in account when pushing changes to our custom catalog.

Avoid lighthouse caching previous versions.

Context: https://kubernetes.slack.com/archives/C9MBGQJRH/p1620127618208700?thread_ts=1618931160.379400&cid=C9MBGQJRH