### PR TITLE
Maintain branch name semantics in git clone

### DIFF
--- a/tasks/git-clone/git-clone-pr.yaml
+++ b/tasks/git-clone/git-clone-pr.yaml
@@ -21,14 +21,16 @@ spec:
     script: |
       #!/bin/sh
       export SUBDIR="source"
-      echo "git cloning url: $REPO_URL version $PULL_PULL_SHA to dir: $SUBDIR"
+      echo "git cloning url: $REPO_URL version $PULL_PULL_REF:$(echo $JOB_NAME | tr '[:lower:]' '[:upper:]')-$PULL_NUMBER@$PULL_PULL_SHA to dir: $SUBDIR"
       git config --global --add user.name ${GIT_AUTHOR_NAME:-jenkins-x-bot}
       git config --global --add user.email ${GIT_AUTHOR_EMAIL:-jenkins-x@googlegroups.com}
       git config --global credential.helper store
       git clone $REPO_URL $SUBDIR
       cd $SUBDIR
-      git checkout $PULL_PULL_SHA
-      echo "checked out revision: $PULL_PULL_SHA to dir: $SUBDIR"
+      git fetch origin $PULL_PULL_REF:$(echo $JOB_NAME | tr '[:lower:]' '[:upper:]')-$PULL_NUMBER
+      git checkout $(echo $JOB_NAME | tr '[:lower:]' '[:upper:]')-$PULL_NUMBER
+      git reset --hard $PULL_PULL_SHA
+      echo "checked out revision: $PULL_PULL_REF:$(echo $JOB_NAME | tr '[:lower:]' '[:upper:]')-$PULL_NUMBER@$PULL_PULL_SHA to dir: $SUBDIR"
     workingDir: /workspace
   - envFrom:
     - secretRef:

--- a/tasks/git-clone/git-clone.yaml
+++ b/tasks/git-clone/git-clone.yaml
@@ -21,14 +21,15 @@ spec:
     script: |
       #!/bin/sh
       export SUBDIR="source"
-      echo "git cloning url: $REPO_URL version $PULL_BASE_SHA to dir: $SUBDIR"
+      echo "git cloning url: $REPO_URL version $PULL_BASE_REF@$PULL_BASE_SHA to dir: $SUBDIR"
       git config --global --add user.name ${GIT_AUTHOR_NAME:-jenkins-x-bot}
       git config --global --add user.email ${GIT_AUTHOR_EMAIL:-jenkins-x@googlegroups.com}
       git config --global credential.helper store
       git clone $REPO_URL $SUBDIR
       cd $SUBDIR
-      git checkout $PULL_BASE_SHA
-      echo "checked out revision: $PULL_BASE_SHA to dir: $SUBDIR"
+      git reset --hard $PULL_BASE_SHA
+      echo "checked out revision: $PULL_BASE_REF@$PULL_BASE_SHA to dir: $SUBDIR"
+
     workingDir: /workspace
   workspaces:
   - description: The git repo will be cloned onto the volume backing this workspace


### PR DESCRIPTION
When you checkout a SHA as it's done here, git goes into detached head mode and loses all the nice metadata related to the branch. Ran into an issue with this when running code coverage tooling which would upload its results and tag it using git metadata.

This achieves the exact same purpose of checking out a particular SHA (note that the clone is hard-reset to the SHA on L30, but within the context of the checked out branch), and maintains the same printing, but is a little cleaner.