### PR TITLE
chore(go-plugin): publish latest tag for container image

### DIFF
--- a/tasks/go-plugin-multiarch/release.yaml
+++ b/tasks/go-plugin-multiarch/release.yaml
@@ -59,7 +59,7 @@ spec:
             #!/busybox/sh
             source .jx/variables.sh
             cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
-            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=gcr.io/$DOCKER_REGISTRY_ORG/$REPO_NAME:$VERSION
+            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=gcr.io/$DOCKER_REGISTRY_ORG/$REPO_NAME:$VERSION --destination=gcr.io/$DOCKER_REGISTRY_ORG/$REPO_NAME:latest
         - image: jnorwood/helm-docs:v1.4.0
           name: chart-docs
           resources: {}

--- a/tasks/go-plugin/release.yaml
+++ b/tasks/go-plugin/release.yaml
@@ -59,7 +59,7 @@ spec:
             #!/busybox/sh
             source .jx/variables.sh
             cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
-            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=ghcr.io/$DOCKER_REGISTRY_ORG/$REPO_NAME:$VERSION
+            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=ghcr.io/$DOCKER_REGISTRY_ORG/$REPO_NAME:$VERSION --destination=ghcr.io/$DOCKER_REGISTRY_ORG/$REPO_NAME:latest
         - image: jnorwood/helm-docs:v1.4.0
           name: chart-docs
           resources: {}


### PR DESCRIPTION
see https://github.com/jenkins-x/issues/issues/44

let's publish our container images with a `latest` tag by default, so that we can reference it from the master/main branches of our git repos (instead of referencing an old tag/version)