### PR TITLE
feat: create lookml pack and pipelines

### DIFF
--- a/packs/lookml/.lighthouse/README.md
+++ b/packs/lookml/.lighthouse/README.md
@@ -1,0 +1,50 @@
+# Looker api credentials
+
+the `build-lookml-datatest` step uses [spectacles CI](https://github.com/spectacles-ci/spectacles) to run looker data tests and sql tests. this requires credentials to authenticate to your pre-production looker instance
+
+for example:
+
+- update the LOOKER_BASE_URL value in your code repo `.lighthouse/pullrequest.yaml`
+- [create an api user](https://docs.spectacles.dev/cli/guides/how-to-create-an-api-key)
+- create a k8s/jenkins-x secret named `looker-sdk` containing the api credentials
+- add/uncomment this `env` block in your code repo's `.lighthouse/pullrequest.yaml`
+
+```yaml
+taskSpec:
+  metadata: {}
+  stepTemplate:
+    env:
+      - name: LOOKER_BASE_URL
+        value: https://looker-api.jx-staging.$YOUR_DOMAIN.com
+      - name: LOOKER_CLIENT_ID
+        valueFrom:
+          secretKeyRef:
+            name: looker-sdk
+            key: client-id
+      - name: LOOKER_CLIENT_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: looker-sdk
+            key: client-secret
+```
+
+alternatively, you could inject looker credentials at run time using [banzaicloud-stable/vault-secrets-webhook](https://github.com/banzaicloud/bank-vaults/tree/master/charts/vault-secrets-webhook)
+
+```yaml
+taskSpec:
+  metadata:
+    annotations:
+      vault.security.banzaicloud.io/vault-addr: "https://vault:8200"
+      vault.security.banzaicloud.io/vault-role: default
+      vault.security.banzaicloud.io/vault-tls-secret: vault-tls
+  stepTemplate:
+    env:
+      - name: LOOKER_BASE_URL
+        value: https://looker-api.jx-staging.$YOUR_DOMAIN.com
+      - name: LOOKER_PROJECT
+        value: $YOUR_LOOKER_PROJECT
+      - name: LOOKER_CLIENT_ID
+        value: vault:secret/data/looker#sdk_client_id
+      - name: LOOKER_CLIENT_SECRET
+        value: vault:secret/data/looker#sdk_client_secret
+```

--- a/packs/lookml/.lighthouse/jenkins-x/lint.yaml
+++ b/packs/lookml/.lighthouse/jenkins-x/lint.yaml
@@ -1,0 +1,81 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  name: lint
+spec:
+  workspaces:
+  - name: output
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+  pipelineSpec:
+    tasks:
+    - name: from-build-pack
+      resources: {}
+      taskSpec:
+        metadata: {}
+        stepTemplate:
+          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/lookml/lint.yaml@versionStream
+          name: ""
+          resources:
+            requests:
+              cpu: 400m
+              memory: 512Mi
+          workingDir: $(workspaces.output.path)/source
+        steps:
+        - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
+          name: ""
+          resources: {}
+        - name: jx-variables
+          resources: {}
+        - name: build-lookml-lint
+          resources: {}
+    finally:
+    - name: lookml-lint-pr-comment
+      workspaces:
+      - name: output
+        workspace: output
+      params:
+      - name: PULL_NUMBER
+        value: $(params.PULL_NUMBER)
+      - name: REPO_URL
+        value: $(params.REPO_URL)
+      taskSpec:
+        workspaces:
+          - name: output
+        metadata: {}
+        params:
+        - default: ""
+          description: git pull request number
+          name: PULL_NUMBER
+          type: string
+        - description: git url to clone
+          name: REPO_URL
+          type: string
+        stepTemplate:
+          env:
+          - name: HOME
+            value: /tekton/home
+          - name: PULL_NUMBER
+            value: $(params.PULL_NUMBER)
+          - name: REPO_URL
+            value: $(params.REPO_URL)
+          name: ""
+          workingDir: $(workspaces.output.path)/source
+        steps:
+        - name: lookml-lint-pr-comment
+          image: ghcr.io/jenkins-x/jx-gitops:0.3.1
+          script: |
+            #!/bin/sh
+            set -x
+            . .jx/variables.sh
+            jx gitops pr comment -c "$(cat issues.md)"
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 12h0m0s
+status: {}

--- a/packs/lookml/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/lookml/.lighthouse/jenkins-x/pullrequest.yaml
@@ -1,0 +1,47 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  name: pullrequest
+spec:
+  pipelineSpec:
+    tasks:
+    - name: from-build-pack
+      resources: {}
+      taskSpec:
+        metadata: {}
+        stepTemplate:
+          env:
+          - name: LOOKER_BASE_URL
+            value: ""
+          - name: LOOKER_CLIENT_ID
+            value: ""
+            # valueFrom:
+            #   secretKeyRef:
+            #     name: looker-sdk
+            #     key: client-id
+          - name: LOOKER_CLIENT_SECRET
+            value: ""
+            # valueFrom:
+            #   secretKeyRef:
+            #     name: looker-sdk
+            #     key: client-secret
+          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/lookml/pullrequest.yaml@versionStream
+          name: ""
+          resources:
+            requests:
+              cpu: 400m
+              memory: 512Mi
+          workingDir: /workspace/source
+        steps:
+        - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
+          name: ""
+          resources: {}
+        - name: jx-variables
+          resources: {}
+        - name: build-lookml-datatest
+          resources: {}
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 12h0m0s
+status: {}

--- a/packs/lookml/.lighthouse/jenkins-x/release.yaml
+++ b/packs/lookml/.lighthouse/jenkins-x/release.yaml
@@ -1,0 +1,38 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  name: release
+spec:
+  pipelineSpec:
+    tasks:
+    - name: from-build-pack
+      resources: {}
+      taskSpec:
+        metadata: {}
+        stepTemplate:
+          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/lookml/release.yaml@versionStream
+          name: ""
+          resources:
+            requests:
+              cpu: 400m
+              memory: 512Mi
+          workingDir: /workspace/source
+        steps:
+        - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
+          name: ""
+          resources: {}
+        - name: next-version
+          resources: {}
+        - name: jx-variables
+          resources: {}
+        - name: promote-changelog
+          resources: {}
+        - name: promote-helm-release
+          resources: {}
+        - name: promote-jx-promote
+          resources: {}
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 12h0m0s
+status: {}

--- a/packs/lookml/.lighthouse/jenkins-x/triggers.yaml
+++ b/packs/lookml/.lighthouse/jenkins-x/triggers.yaml
@@ -1,0 +1,23 @@
+apiVersion: config.lighthouse.jenkins-x.io/v1alpha1
+kind: TriggerConfig
+spec:
+  presubmits:
+  - name: lint
+    context: "lint"
+    always_run: true
+    optional: false
+    trigger: "(?:/lint|/relint)"
+    rerun_command: "/relint"
+    source: "lint.yaml"
+  - name: pr
+    context: "pr"
+    always_run: true
+    optional: false
+    source: "pullrequest.yaml"
+  postsubmits:
+  - name: release
+    context: "release"
+    source: "release.yaml"
+    branches:
+    - ^main$
+    - ^master$

--- a/packs/lookml/charts/.helmignore
+++ b/packs/lookml/charts/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/packs/lookml/charts/Chart.yaml
+++ b/packs/lookml/charts/Chart.yaml
@@ -1,0 +1,5 @@
+name: REPLACE_ME_APP_NAME
+description: this chart merely runs a post-install/upgrade hook to curl the looker deploy webhook
+apiVersion: v2
+version: 0.1.0-SNAPSHOT
+icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png

--- a/packs/lookml/charts/Kptfile
+++ b/packs/lookml/charts/Kptfile
@@ -1,0 +1,11 @@
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: charts
+upstream:
+  type: git
+  git:
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master

--- a/packs/lookml/charts/Makefile
+++ b/packs/lookml/charts/Makefile
@@ -1,0 +1,45 @@
+CHART_REPO := http://jenkins-x-chartmuseum:8080
+CURRENT=$(pwd)
+NAME := REPLACE_ME_APP_NAME
+OS := $(shell uname)
+RELEASE_VERSION := $(shell cat ../../VERSION)
+
+build: clean
+	rm -rf requirements.lock
+	helm dependency build
+	helm lint
+
+install: clean build
+	helm install . --name ${NAME}
+
+upgrade: clean build
+	helm upgrade ${NAME} .
+
+delete:
+	helm delete --purge ${NAME}
+
+clean:
+	rm -rf charts
+	rm -rf ${NAME}*.tgz
+
+release: clean
+	helm dependency build
+	helm lint
+	helm init --client-only
+	helm package .
+	curl --fail -u $(CHARTMUSEUM_CREDS_USR):$(CHARTMUSEUM_CREDS_PSW) --data-binary "@$(NAME)-$(shell sed -n 's/^version: //p' Chart.yaml).tgz" $(CHART_REPO)/api/charts
+	rm -rf ${NAME}*.tgz%
+
+tag:
+ifeq ($(OS),Darwin)
+	sed -i "" -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
+else ifeq ($(OS),Linux)
+	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
+else
+	echo "platfrom $(OS) not supported to release from"
+	exit -1
+endif
+	git add --all
+	git commit -m "chore: release $(RELEASE_VERSION)" --allow-empty # if first release then no verion update is performed
+	git tag -fa v$(RELEASE_VERSION) -m "Release version $(RELEASE_VERSION)"
+	git push origin v$(RELEASE_VERSION)

--- a/packs/lookml/charts/README.md
+++ b/packs/lookml/charts/README.md
@@ -1,0 +1,3 @@
+# REPLACE_ME_APP_NAME
+ 
+this chart merely runs a post-install/upgrade hook to curl the looker deploy webhook

--- a/packs/lookml/charts/templates/NOTES.txt
+++ b/packs/lookml/charts/templates/NOTES.txt
@@ -1,0 +1,2 @@
+this chart merely runs a post-install/upgrade hook to curl the looker deploy webhook
+kubectl get pods --namespace {{ .Release.Namespace }}

--- a/packs/lookml/charts/templates/_helpers.tpl
+++ b/packs/lookml/charts/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/packs/lookml/charts/templates/deploy-hook-job.yaml
+++ b/packs/lookml/charts/templates/deploy-hook-job.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-lookml-deploy"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    helm.sh/hook: post-install,post-upgrade
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-lookml-deploy"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: curl-looker-deploy-endpoint
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - curl
+        - -L
+        - {{ .Values.looker.deployWebhookUrl }}
+

--- a/packs/lookml/charts/values.yaml
+++ b/packs/lookml/charts/values.yaml
@@ -1,0 +1,69 @@
+# Default values for your projects.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+looker:
+  deployWebhookUrl: ""
+
+image:
+  repository: curlimages/curl
+  tag: 7.77.0
+  pullPolicy: IfNotPresent
+
+# optional list of image pull secrets to use to pull images
+jx:
+  # optional image pull secrets
+  imagePullSecrets: []
+
+  # whether to create a Release CRD when installing charts with Release CRDs included
+  releaseCRD: true
+
+# Canary deployments
+# If enabled, Istio and Flagger need to be installed in the cluster
+canary:
+  enabled: false
+  progressDeadlineSeconds: 60
+  analysis:
+    interval: "1m"
+    threshold: 5
+    maxWeight: 60
+    stepWeight: 20
+    # WARNING: Canary deployments will fail and rollback if there is no traffic that will generate the below specified metrics.
+    metrics:
+      latency:
+        threshold: 500
+        interval: "1m"
+  # The host is using Istio Gateway or the underlying ingress mechanism
+  # This value is defaulted from the environments jx-requirements.yml ingress configuration
+  host: ""
+  # Add labels to the canary
+  labels: {}
+  # Add labels to the canary gateway
+  gatewayLabels: {}
+
+resources:
+  limits:
+    cpu: 400m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+# values we use from the `jx-requirements.yml` file if we are using helmfile and helm 3
+jxRequirements:
+  ingress:
+    # shared ingress annotations on all services
+    annotations: {}
+    #  kubernetes.io/ingress.class: nginx
+
+    apiVersion: "networking.k8s.io/v1"
+
+    # the domain for hosts
+    domain: ""
+    externalDNS: false
+    namespaceSubDomain: -jx.
+    serviceType: ""
+    tls:
+      email: ""
+      enabled: false
+      production: false
+      secretName: ""

--- a/tasks/lookml/lint.yaml
+++ b/tasks/lookml/lint.yaml
@@ -1,0 +1,56 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  name: lint
+spec:
+  pipelineSpec:
+    workspaces:
+    - name: output
+    tasks:
+    - name: from-build-pack
+      workspaces:
+      - name: output
+        workspace: output
+      resources: {}
+      taskSpec:
+        workspaces:
+        - name: output
+        metadata: {}
+        stepTemplate:
+          env:
+          - name: NPM_CONFIG_USERCONFIG
+            value: /tekton/home/npm/.npmrc
+          - name: HOME
+            value: /tekton/home
+          envFrom:
+          - secretRef:
+              name: jx-boot-job-env-vars
+              optional: true
+          name: ""
+          resources:
+            requests:
+              cpu: 400m
+              memory: 512Mi
+          workingDir: $(workspaces.output.path)/source
+        steps:
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.169
+          name: jx-variables
+          resources: {}
+          script: |
+            #!/usr/bin/env sh
+            jx gitops variables
+            jx gitops pr variables
+        - image: node:12-slim
+          name: build-lookml-lint
+          resources: {}
+          script: |
+            #!/bin/sh
+            npm install -g @looker/look-at-me-sideways --allow-root --unsafe-perm=true
+            lams --reporting=no \
+              --allow-custom-rules \
+              --jenkins
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 12h0m0s
+status: {}

--- a/tasks/lookml/pullrequest.yaml
+++ b/tasks/lookml/pullrequest.yaml
@@ -1,0 +1,56 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  name: pullrequest
+spec:
+  pipelineSpec:
+    tasks:
+    - name: from-build-pack
+      resources: {}
+      taskSpec:
+        metadata: {}
+        stepTemplate:
+          env:
+          - name: HOME
+            value: /tekton/home
+          envFrom:
+          - secretRef:
+              name: jx-boot-job-env-vars
+              optional: true
+          name: ""
+          resources:
+            requests:
+              cpu: 400m
+              memory: 512Mi
+          workingDir: /workspace/source
+        steps:
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.169
+          name: jx-variables
+          resources: {}
+          script: |
+            #!/usr/bin/env sh
+            jx gitops variables
+            jx gitops pr variables
+        - image: python:3.7-alpine
+          name: build-lookml-datatest
+          resources: {}
+          script: |
+            #!/bin/sh
+            . .jx/variables.sh
+            pip install spectacles
+            set -x 
+            spectacles assert \
+              --port 443 \
+              --branch $PR_HEAD_REF \
+              --remote-reset
+
+            spectacles sql \
+              --port 443 \
+              --branch $PR_HEAD_REF \
+              --remote-reset \
+              --mode batch
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 12h0m0s
+status: {}

--- a/tasks/lookml/release.yaml
+++ b/tasks/lookml/release.yaml
@@ -1,0 +1,85 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  name: release
+spec:
+  pipelineSpec:
+    tasks:
+    - name: from-build-pack
+      resources: {}
+      taskSpec:
+        metadata: {}
+        stepTemplate:
+          env:
+          - name: HOME
+            value: /tekton/home
+          envFrom:
+          - secretRef:
+              name: jx-boot-job-env-vars
+              optional: true
+          name: ""
+          resources:
+            requests:
+              cpu: 400m
+              memory: 512Mi
+          workingDir: /workspace/source
+        steps:
+        - env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                key: password
+                name: tekton-git
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                key: username
+                name: tekton-git
+          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          name: next-version
+          resources: {}
+          script: |
+            #!/usr/bin/env sh
+            jx-release-version --tag > VERSION
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.169
+          name: jx-variables
+          resources: {}
+          script: |
+            #!/usr/bin/env sh
+            jx gitops variables
+        - image: ghcr.io/jenkins-x/jx-changelog:0.0.43
+          name: promote-changelog
+          resources: {}
+          script: |
+            #!/usr/bin/env sh
+            source .jx/variables.sh
+
+            if [ -d "charts/$REPO_NAME" ]; then
+            jx gitops yset -p version -v "$VERSION" -f ./charts/$REPO_NAME/Chart.yaml
+            else echo no charts; fi
+
+            git add * || true
+            git commit -a -m "chore: release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push --force origin v$VERSION
+
+            jx changelog create --version v${VERSION}
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.169
+          name: promote-helm-release
+          resources: {}
+          script: |
+            #!/usr/bin/env sh
+            source .jx/variables.sh
+            jx gitops helm release
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.274
+          name: promote-jx-promote
+          resources: {}
+          script: |
+            #!/usr/bin/env sh
+            source .jx/variables.sh
+            jx promote -b --all --timeout 1h --no-poll
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 12h0m0s
+status: {}


### PR DESCRIPTION
### pack and pipelines for [lookml](https://docs.looker.com/data-modeling/learning-lookml/what-is-lookml)

- linting using [look at me sideways](https://github.com/looker-open-source/look-at-me-sideways)
- data tests and sql validation tests using [spectacles CI](https://github.com/spectacles-ci/spectacles). README.md contains instructions on setting up required api credentials
- release pipeline ships a helm chart which curls an arbitrary looker endpoint

typically, you don't bake a docker image containing lookml code. it's synced straight from git to the looker instance. the included chart defaults to using curl to hit the looker instance deploy endpoint, but can be customized to include a docker image that runs looker api commands, etc

