### PR TITLE
fix: drop up to 2 'regenerate' commits on merge conflict

### DIFF
--- a/tasks/git-clone/git-clone-env-pr.yaml
+++ b/tasks/git-clone/git-clone-env-pr.yaml
@@ -45,8 +45,17 @@ spec:
     resources: {}
     script: |
       #!/usr/bin/env sh
-      # lets avoid git rebase/merge conflicts on promotions
-      jx gitops git merge --rebase --merge-arg "-Xtheirs"
+      counter=0
+      until [ "$counter" -eq 3 ]; do
+        # lets avoid git rebase/merge conflicts on promotions
+        jx gitops git merge --rebase --merge-arg "-Xtheirs" && exit 0
+        counter=$((counter+1))
+        git rebase --abort
+        if git log -1 --pretty=%B | grep -i regenerate; then
+          git reset --hard HEAD~1
+        fi
+      done
+      exit 1
     workingDir: /workspace/source
   workspaces:
   - description: The git repo will be cloned onto the volume backing this workspace


### PR DESCRIPTION
in my multicluster setup, i frequently get merge conflicts in my automated production promotion cluster PRs. these are usually related to `jx-verify` config-root files. `jx gitops upgrade`-ing my cluster hasn't helped. i also occasionally get similar conflicts in my dev/staging cluster.
related slack thread: https://kubernetes.slack.com/archives/C9MBGQJRH/p1625017001157400

the changes in this pr would drop the previous commit if `jx gitops git merge --rebase --merge-arg "-Xtheirs"` fails and if the commit title contains the string 'regenerate'. 