### PR TITLE
feat: add a lint step for go pr task

### DIFF
--- a/tasks/go-plugin/pullrequest.yaml
+++ b/tasks/go-plugin/pullrequest.yaml
@@ -38,6 +38,12 @@ spec:
           script: |
             #!/bin/sh
             make linux
+        - image: golangci/golangci-lint:v1.42.1-alpine
+          name: make-lint
+          resources: {}
+          script: |
+            #!/bin/sh
+            golangci-lint run --verbose --deadline 15m0s
         - image: golang:1.15
           name: build-make-test
           resources: {}

--- a/tasks/go/pullrequest.yaml
+++ b/tasks/go/pullrequest.yaml
@@ -38,6 +38,12 @@ spec:
           script: |
             #!/bin/sh
             make linux
+        - image: golangci/golangci-lint:v1.42.1-alpine
+          name: make-lint
+          resources: {}
+          script: |
+            #!/bin/sh
+            golangci-lint run --verbose --deadline 15m0s
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

We could use this for the JX pipelines, instead of running the hack/linter.sh script, which can now be used for local development.