### PR TITLE
fix: allow templated values in podAnnotations

### DIFF
--- a/helm/charts/templates/deployment.yaml
+++ b/helm/charts/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
 {{- end }}
 {{- if .Values.podAnnotations }}
       annotations:
-{{ toYaml .Values.podAnnotations | indent 8 }}
+{{ tpl (toYaml .Values.podAnnotations) $ | indent 8 }}
 {{- end }}
     spec:
 {{- if .Values.serviceAccount.enabled }}


### PR DESCRIPTION
I have a use case to use dynamic values in `.Values.podAnnotations`. I'd imagine other folks will eventually encounter something similar.

values.yaml:
```yaml
# Add annotations to the pods
podAnnotations:
  vault.security.banzaicloud.io/vault-agent-configmap: '{{ template "fullname" . }}-configs'
```