### PR TITLE
build: upgraded node version to the LTS

### DIFF
--- a/tasks/javascript-ui-nginx/pullrequest.yaml
+++ b/tasks/javascript-ui-nginx/pullrequest.yaml
@@ -32,19 +32,19 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: node:16.13-slim
+        - image: node:lts-slim
           name: build-npm-install
           resources: {}
           script: |
             #!/bin/sh
             npm install
-        - image: node:16.13-slim
+        - image: node:lts-slim
           name: build-npm-test
           resources: {}
           script: |
             #!/bin/sh
             CI=true DISPLAY=:99 npm test
-        - image: node:16.13-slim
+        - image: node:lts-slim
           name: build-ui-build
           resources: {}
           script: |

--- a/tasks/javascript-ui-nginx/pullrequest.yaml
+++ b/tasks/javascript-ui-nginx/pullrequest.yaml
@@ -32,19 +32,19 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: node:12-slim
+        - image: node:16.13-slim
           name: build-npm-install
           resources: {}
           script: |
             #!/bin/sh
             npm install
-        - image: node:12-slim
+        - image: node:16.13-slim
           name: build-npm-test
           resources: {}
           script: |
             #!/bin/sh
             CI=true DISPLAY=:99 npm test
-        - image: node:12-slim
+        - image: node:16.13-slim
           name: build-ui-build
           resources: {}
           script: |

--- a/tasks/javascript-ui-nginx/release.yaml
+++ b/tasks/javascript-ui-nginx/release.yaml
@@ -53,19 +53,19 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: node:16.13-slim
+        - image: node:lts-slim
           name: build-npm-install
           resources: {}
           script: |
             #!/bin/sh
             npm install
-        - image: node:16.13-slim
+        - image: node:lts-slim
           name: build-npm-test
           resources: {}
           script: |
             #!/bin/sh
             CI=true DISPLAY=:99 npm test
-        - image: node:16.13-slim
+        - image: node:lts-slim
           name: build-ui-build
           resources: {}
           script: |

--- a/tasks/javascript-ui-nginx/release.yaml
+++ b/tasks/javascript-ui-nginx/release.yaml
@@ -53,19 +53,19 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: node:12-slim
+        - image: node:16.13-slim
           name: build-npm-install
           resources: {}
           script: |
             #!/bin/sh
             npm install
-        - image: node:12-slim
+        - image: node:16.13-slim
           name: build-npm-test
           resources: {}
           script: |
             #!/bin/sh
             CI=true DISPLAY=:99 npm test
-        - image: node:12-slim
+        - image: node:16.13-slim
           name: build-ui-build
           resources: {}
           script: |

--- a/tasks/javascript/pullrequest.yaml
+++ b/tasks/javascript/pullrequest.yaml
@@ -37,13 +37,13 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: node:12-slim
+        - image: node:16.13-slim
           name: build-npm-install
           resources: {}
           script: |
             #!/bin/sh
             npm install
-        - image: node:12-slim
+        - image: node:16.13-slim
           name: build-npm-test
           resources: {}
           script: |

--- a/tasks/javascript/pullrequest.yaml
+++ b/tasks/javascript/pullrequest.yaml
@@ -37,13 +37,13 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: node:16.13-slim
+        - image: node:lts-slim
           name: build-npm-install
           resources: {}
           script: |
             #!/bin/sh
             npm install
-        - image: node:16.13-slim
+        - image: node:lts-slim
           name: build-npm-test
           resources: {}
           script: |

--- a/tasks/javascript/release.yaml
+++ b/tasks/javascript/release.yaml
@@ -53,13 +53,13 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: node:16.13-slim
+        - image: node:lts-slim
           name: build-npm-install
           resources: {}
           script: |
             #!/bin/sh
             npm install
-        - image: node:16.13-slim
+        - image: node:lts-slim
           name: build-npm-test
           resources: {}
           script: |

--- a/tasks/javascript/release.yaml
+++ b/tasks/javascript/release.yaml
@@ -53,13 +53,13 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: node:12-slim
+        - image: node:16.13-slim
           name: build-npm-install
           resources: {}
           script: |
             #!/bin/sh
             npm install
-        - image: node:12-slim
+        - image: node:16.13-slim
           name: build-npm-test
           resources: {}
           script: |


### PR DESCRIPTION
Given that node 12.0 is in Maintenance phase as per [[1]](https://nodejs.org/en/about/releases/) I upgraded all of the node images to the 16.13 LTS version

One improvement would be to use `lts-slim` docker image instead but I'm not sure about how Jenkins intends to manage dependency updates. In case i can submit a PR for that as well

Signed-off-by: thevinter <theniki98@gmail.com>