### PR TITLE
fix: Update internalPort to match nginx config

### DIFF
--- a/packs/javascript-ui-nginx/charts/values.yaml
+++ b/packs/javascript-ui-nginx/charts/values.yaml
@@ -65,7 +65,7 @@ service:
   name: REPLACE_ME_APP_NAME
   type: ClusterIP
   externalPort: 80
-  internalPort: 8080
+  internalPort: 80
   annotations: {}
   # Add labels to the service
   labels: {}


### PR DESCRIPTION
The image used in the dockerfile is nginx:alpine-stable, which has nginx configured to listen on port 80, thus I have changed internalPort to 80.