### PR TITLE
fix: lower excessive resource consumption with tekton 28.0.0+

### DIFF
--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,9 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/go/release.yaml@a5ab19ebc5a074e0402c5016b11bc11b32cc5c83
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
@@ -25,7 +24,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
         - env:
           - name: GH_ACCESS_TOKEN
             valueFrom:

--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/go/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -25,7 +24,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
         - name: promote-changelog
           resources: {}
         - image: ghcr.io/jenkins-x/jx-changelog:0.1.3

--- a/environment-remote/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/environment-remote/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,15 +14,18 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/environment/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-env-pr.yaml@versionStream
           resources: {}
         - name: make-pr
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
   podTemplate: {}
   serviceAccountName: tekton-bot
   timeout: 12h0m0s

--- a/environment/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/environment/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,9 +14,7 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/environment/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 0.1
-              memory: 128Mi
+            # override limits for all containers here
             limits:
               cpu: 400m
               memory: 512Mi
@@ -25,7 +23,11 @@ spec:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-env-pr.yaml@versionStream
           resources: {}
         - name: make-pr
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 0.1
+              memory: 128Mi
   podTemplate: {}
   serviceAccountName: tekton-bot
   timeout: 12h0m0s

--- a/environment/.lighthouse/jenkins-x/release.yaml
+++ b/environment/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,7 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/environment/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 0.1
-              memory: 128Mi
+            # override limits for all containers here
             limits:
               cpu: 400m
               memory: 256Mi
@@ -26,7 +24,11 @@ spec:
           name: ""
           resources: {}
         - name: admin-log
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 0.1
+              memory: 128Mi
   podTemplate: {}
   serviceAccountName: tekton-bot
   timeout: 12h0m0s

--- a/packs/D/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/D/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/D/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 500m
-              memory: 1Gi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 500m
+              memory: 1Gi
         - name: build-dub-build
           resources: {}
         - name: check-registry

--- a/packs/D/.lighthouse/jenkins-x/release.yaml
+++ b/packs/D/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/D/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 500m
-              memory: 1Gi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -25,7 +24,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 500m
+              memory: 1Gi
         - name: build-dub-build
           resources: {}
         - name: check-registry

--- a/packs/apps/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/apps/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/apps/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
         - name: build-build
           resources: {}
         - name: build-helm-build

--- a/packs/apps/.lighthouse/jenkins-x/release.yaml
+++ b/packs/apps/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/apps/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -25,7 +24,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
         - name: build-build
           resources: {}
         - name: release-chart

--- a/packs/appserver/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/appserver/.lighthouse/jenkins-x/pullrequest.yaml
@@ -22,16 +22,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/appserver/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-set-version
           resources: {}
         - name: build-mvn-install

--- a/packs/appserver/.lighthouse/jenkins-x/release.yaml
+++ b/packs/appserver/.lighthouse/jenkins-x/release.yaml
@@ -22,9 +22,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/appserver/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -33,7 +32,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-mvn-deploy
           resources: {}
         - name: check-registry

--- a/packs/csharp/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/csharp/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/csharp/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 200m
-              memory: 256Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 200m
+              memory: 256Mi
         - name: check-registry
           resources: {}
         - name: build-container-build

--- a/packs/csharp/.lighthouse/jenkins-x/release.yaml
+++ b/packs/csharp/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/csharp/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 200m
-              memory: 256Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -25,7 +24,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 200m
+              memory: 256Mi
         - name: check-registry
           resources: {}
         - name: build-container-build

--- a/packs/custom-jenkins/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/custom-jenkins/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/custom-jenkins/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
         - name: build-build
           resources: {}
   podTemplate: {}

--- a/packs/custom-jenkins/.lighthouse/jenkins-x/release.yaml
+++ b/packs/custom-jenkins/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/custom-jenkins/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -25,7 +24,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
         - name: build-build
           resources: {}
   podTemplate: {}

--- a/packs/cwp/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/cwp/.lighthouse/jenkins-x/pullrequest.yaml
@@ -22,16 +22,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/cwp/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-set-version
           resources: {}
         - name: build-mvn-install

--- a/packs/cwp/.lighthouse/jenkins-x/release.yaml
+++ b/packs/cwp/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/cwp/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -25,7 +24,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-mvn-deploy
           resources: {}
         - name: check-registry

--- a/packs/docker-helm/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/docker-helm/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/docker-helm/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: check-registry
           resources: {}
         - name: build-container-build

--- a/packs/docker-helm/.lighthouse/jenkins-x/release.yaml
+++ b/packs/docker-helm/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/docker-helm/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -25,7 +24,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: check-registry
           resources: {}
         - name: build-container-build

--- a/packs/docker/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/docker/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/docker/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: check-registry
           resources: {}
         - name: build-container-build

--- a/packs/docker/.lighthouse/jenkins-x/release.yaml
+++ b/packs/docker/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/docker/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -25,7 +24,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: check-registry
           resources: {}
         - name: build-container-build

--- a/packs/flutter/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/flutter/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/flutter/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build
           resources: {}
   podTemplate: {}

--- a/packs/flutter/.lighthouse/jenkins-x/release.yaml
+++ b/packs/flutter/.lighthouse/jenkins-x/release.yaml
@@ -17,9 +17,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/flutter/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           volumeMounts:
           - mountPath: /tekton/home/npm
             name: npmrc
@@ -31,7 +30,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build
           resources: {}
         - name: promote-release

--- a/packs/git/.lighthouse/jenkins-x/release.yaml
+++ b/packs/git/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,8 @@ spec:
         stepTemplate:
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-release-version:2.5.1
@@ -38,7 +37,11 @@ spec:
                 key: username
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/packs/go-cli/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/go-cli/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/go-cli/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
         - name: build-make-linux
           resources: {}
         - name: build-make-test

--- a/packs/go-cli/.lighthouse/jenkins-x/release.yaml
+++ b/packs/go-cli/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/go-cli/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -25,7 +24,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
         - name: build-make-build
           resources: {}
         - name: check-registry

--- a/packs/go-mongodb/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/go-mongodb/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/go-mongodb/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
         - name: build-make-linux
           resources: {}
         - name: check-registry

--- a/packs/go-mongodb/.lighthouse/jenkins-x/release.yaml
+++ b/packs/go-mongodb/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/go-mongodb/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -25,7 +24,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
         - name: build-make-build
           resources: {}
         - name: check-registry

--- a/packs/go-plugin-multiarch/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/go-plugin-multiarch/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/go-plugin-multiarch/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
         - name: build-make-linux
           resources: {}
         - name: build-make-test

--- a/packs/go-plugin/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/go-plugin/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/go-plugin/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
         - name: build-make-linux
           resources: {}
         - name: build-make-test

--- a/packs/go/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/go/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/go/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
         - name: build-make-linux
           resources: {}
         - name: check-registry

--- a/packs/go/.lighthouse/jenkins-x/release.yaml
+++ b/packs/go/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/go/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -25,7 +24,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
         - name: build-make-build
           resources: {}
         - name: check-registry

--- a/packs/gradle/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/gradle/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/gradle/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-gradle-build
           resources: {}
         - name: check-registry

--- a/packs/gradle/.lighthouse/jenkins-x/release.yaml
+++ b/packs/gradle/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/gradle/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -25,7 +24,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-gradle-build
           resources: {}
         - name: check-registry

--- a/packs/helm/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/helm/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/helm/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-helm-build
           resources: {}
   podTemplate: {}

--- a/packs/helm/.lighthouse/jenkins-x/release.yaml
+++ b/packs/helm/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/helm/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -25,7 +24,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: promote-changelog
           resources: {}
         - name: promote-helm-release

--- a/packs/javascript-ui-nginx/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/javascript-ui-nginx/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/javascript-ui-nginx/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-npm-install
           resources: {}
         - name: build-npm-test

--- a/packs/javascript-ui-nginx/.lighthouse/jenkins-x/release.yaml
+++ b/packs/javascript-ui-nginx/.lighthouse/jenkins-x/release.yaml
@@ -17,9 +17,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/javascript-ui-nginx/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           volumeMounts:
           - mountPath: /tekton/home/npm
             name: npmrc
@@ -31,7 +30,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-npm-install
           resources: {}
         - name: build-npm-test

--- a/packs/javascript/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/javascript/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,9 +14,7 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/javascript/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 0.1
-              memory: 128Mi
+            # override limits for all containers here
             limits:
               cpu: 400m
               memory: 512Mi
@@ -26,7 +24,11 @@ spec:
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 0.1
+              memory: 128Mi
         - name: build-npm-install
           resources: {}
         - name: build-npm-test

--- a/packs/javascript/.lighthouse/jenkins-x/release.yaml
+++ b/packs/javascript/.lighthouse/jenkins-x/release.yaml
@@ -17,9 +17,7 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/javascript/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 0.1
-              memory: 128Mi
+            # override limits for all containers here
             limits:
               cpu: 400m
               memory: 512Mi
@@ -34,7 +32,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 0.1
+              memory: 128Mi
         - name: build-npm-install
           resources: {}
         - name: build-npm-test

--- a/packs/jenkins/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/jenkins/.lighthouse/jenkins-x/pullrequest.yaml
@@ -22,16 +22,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/jenkins/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: check-registry
           resources: {}
         - name: build-container-build

--- a/packs/jenkins/.lighthouse/jenkins-x/release.yaml
+++ b/packs/jenkins/.lighthouse/jenkins-x/release.yaml
@@ -22,9 +22,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/jenkins/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -33,7 +32,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: check-registry
           resources: {}
         - name: build-container-build

--- a/packs/lookml/.lighthouse/jenkins-x/lint.yaml
+++ b/packs/lookml/.lighthouse/jenkins-x/lint.yaml
@@ -23,16 +23,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/lookml/lint.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: $(workspaces.output.path)/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-lookml-lint
           resources: {}
     finally:

--- a/packs/lookml/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/lookml/.lighthouse/jenkins-x/pullrequest.yaml
@@ -29,16 +29,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/lookml/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-lookml-datatest
           resources: {}
   podTemplate: {}

--- a/packs/lookml/.lighthouse/jenkins-x/release.yaml
+++ b/packs/lookml/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/lookml/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -25,7 +24,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: promote-changelog
           resources: {}
         - name: promote-helm-release

--- a/packs/maven-java11/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/maven-java11/.lighthouse/jenkins-x/pullrequest.yaml
@@ -21,9 +21,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/maven-java11/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -33,7 +32,11 @@ spec:
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-set-version
           resources: {}
         - name: build-mvn-install

--- a/packs/maven-java11/.lighthouse/jenkins-x/release.yaml
+++ b/packs/maven-java11/.lighthouse/jenkins-x/release.yaml
@@ -21,9 +21,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/maven-java11/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -37,7 +36,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-mvn-deploy
           resources: {}
         - name: check-registry

--- a/packs/maven-java14/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/maven-java14/.lighthouse/jenkins-x/pullrequest.yaml
@@ -21,9 +21,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/maven-java14/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -33,7 +32,11 @@ spec:
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-set-version
           resources: {}
         - name: build-mvn-install

--- a/packs/maven-java14/.lighthouse/jenkins-x/release.yaml
+++ b/packs/maven-java14/.lighthouse/jenkins-x/release.yaml
@@ -21,9 +21,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/maven-java14/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -37,7 +36,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-mvn-deploy
           resources: {}
         - name: check-registry

--- a/packs/maven-java16/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/maven-java16/.lighthouse/jenkins-x/pullrequest.yaml
@@ -17,9 +17,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/maven-java16/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -29,7 +28,11 @@ spec:
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-set-version
           resources: {}
         - name: build-mvn-install

--- a/packs/maven-java16/.lighthouse/jenkins-x/release.yaml
+++ b/packs/maven-java16/.lighthouse/jenkins-x/release.yaml
@@ -17,9 +17,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/maven-java16/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -33,7 +32,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-mvn-deploy
           resources: {}
         - name: check-registry

--- a/packs/maven-java17/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/maven-java17/.lighthouse/jenkins-x/pullrequest.yaml
@@ -17,9 +17,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/maven-java17/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -29,7 +28,11 @@ spec:
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-set-version
           resources: {}
         - name: build-mvn-install

--- a/packs/maven-java17/.lighthouse/jenkins-x/release.yaml
+++ b/packs/maven-java17/.lighthouse/jenkins-x/release.yaml
@@ -17,9 +17,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/maven-java17/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -33,7 +32,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-mvn-deploy
           resources: {}
         - name: check-registry

--- a/packs/maven-node-ruby/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/maven-node-ruby/.lighthouse/jenkins-x/pullrequest.yaml
@@ -23,9 +23,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/maven-node-ruby/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -35,7 +34,11 @@ spec:
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-set-version
           resources: {}
         - name: build-mvn-install

--- a/packs/maven-node-ruby/.lighthouse/jenkins-x/release.yaml
+++ b/packs/maven-node-ruby/.lighthouse/jenkins-x/release.yaml
@@ -22,9 +22,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/maven-node-ruby/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -38,7 +37,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-mvn-deploy
           resources: {}
         - name: check-registry

--- a/packs/maven-quarkus-native/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/maven-quarkus-native/.lighthouse/jenkins-x/pullrequest.yaml
@@ -21,9 +21,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/maven-quarkus-native/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 2Gi
+            # override limits for all containers here
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -33,7 +32,11 @@ spec:
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 2Gi
         - name: build-set-version
           resources: {}
         - name: build-mvn-install

--- a/packs/maven-quarkus-native/.lighthouse/jenkins-x/release.yaml
+++ b/packs/maven-quarkus-native/.lighthouse/jenkins-x/release.yaml
@@ -22,9 +22,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/maven-quarkus-native/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 2Gi
+            # override limits for all containers here
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -38,7 +37,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 2Gi
         - name: build-mvn-deploy
           resources: {}
         - name: check-registry

--- a/packs/maven-quarkus/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/maven-quarkus/.lighthouse/jenkins-x/pullrequest.yaml
@@ -21,9 +21,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/maven-quarkus/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 2Gi
+            # override limits for all containers here
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -33,7 +32,11 @@ spec:
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 2Gi
         - name: build-set-version
           resources: {}
         - name: build-mvn-install

--- a/packs/maven-quarkus/.lighthouse/jenkins-x/release.yaml
+++ b/packs/maven-quarkus/.lighthouse/jenkins-x/release.yaml
@@ -21,9 +21,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/maven-quarkus/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 2Gi
+            # override limits for all containers here
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -37,7 +36,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 2Gi
         - name: build-mvn-deploy
           resources: {}
         - name: check-registry

--- a/packs/maven/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/maven/.lighthouse/jenkins-x/pullrequest.yaml
@@ -22,9 +22,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/maven/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -34,7 +33,11 @@ spec:
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-set-version
           resources: {}
         - name: build-mvn-install

--- a/packs/maven/.lighthouse/jenkins-x/release.yaml
+++ b/packs/maven/.lighthouse/jenkins-x/release.yaml
@@ -22,9 +22,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/maven/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -38,7 +37,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-mvn-deploy
           resources: {}
         - name: check-registry

--- a/packs/ml-python-gpu-service/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/ml-python-gpu-service/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/ml-python-gpu-service/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: "1"
-              memory: 1Gi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: "1"
+              memory: 1Gi
         - name: build-step2
           resources: {}
         - name: build-flake8

--- a/packs/ml-python-gpu-service/.lighthouse/jenkins-x/release.yaml
+++ b/packs/ml-python-gpu-service/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/ml-python-gpu-service/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: "1"
-              memory: 1Gi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -25,7 +24,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: "1"
+              memory: 1Gi
         - name: setup-step3
           resources: {}
         - name: build-flake8

--- a/packs/ml-python-gpu-training/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/ml-python-gpu-training/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/ml-python-training/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: "2"
-              memory: 4Gi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: "2"
+              memory: 4Gi
         - name: build-flake8
           resources: {}
         - name: build-testing

--- a/packs/ml-python-gpu-training/.lighthouse/jenkins-x/release.yaml
+++ b/packs/ml-python-gpu-training/.lighthouse/jenkins-x/release.yaml
@@ -14,10 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/ml-python-gpu-training/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: "1"
-              memory: 4Gi
-              nvidia.com/gpu: 0
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -26,7 +24,12 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: "1"
+              memory: 4Gi
+              nvidia.com/gpu: 0
         - name: build-flake8
           resources: {}
         - name: build-training

--- a/packs/ml-python-service/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/ml-python-service/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/ml-python-service/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: "2"
-              memory: 4Gi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: "2"
+              memory: 4Gi
         - name: build-step2
           resources: {}
         - name: build-flake8

--- a/packs/ml-python-service/.lighthouse/jenkins-x/release.yaml
+++ b/packs/ml-python-service/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/ml-python-service/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: "2"
-              memory: 4Gi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -25,7 +24,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: "2"
+              memory: 4Gi
         - name: setup-step3
           resources: {}
         - name: build-flake8

--- a/packs/ml-python-training/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/ml-python-training/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/ml-python-training/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: "2"
-              memory: 4Gi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: "2"
+              memory: 4Gi
         - name: build-flake8
           resources: {}
         - name: build-testing

--- a/packs/ml-python-training/.lighthouse/jenkins-x/release.yaml
+++ b/packs/ml-python-training/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/ml-python-training/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: "2"
-              memory: 4Gi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -25,7 +24,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: "2"
+              memory: 4Gi
         - name: build-flake8
           resources: {}
         - name: build-training

--- a/packs/php/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/php/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/php/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 200m
-              memory: 256Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 200m
+              memory: 256Mi
         - name: check-registry
           resources: {}
         - name: build-container-build

--- a/packs/php/.lighthouse/jenkins-x/release.yaml
+++ b/packs/php/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/php/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 200m
-              memory: 256Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -25,7 +24,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 200m
+              memory: 256Mi
         - name: check-registry
           resources: {}
         - name: build-container-build

--- a/packs/python/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/python/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/python/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-python-unittest
           resources: {}
         - name: check-registry

--- a/packs/python/.lighthouse/jenkins-x/release.yaml
+++ b/packs/python/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/python/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -25,7 +24,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-python-unittest
           resources: {}
         - name: check-registry

--- a/packs/ruby/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/ruby/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/ruby/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: check-registry
           resources: {}
         - name: build-container-build

--- a/packs/ruby/.lighthouse/jenkins-x/release.yaml
+++ b/packs/ruby/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/ruby/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -25,7 +24,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: check-registry
           resources: {}
         - name: build-container-build

--- a/packs/rust/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/rust/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/rust/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-cargo-install
           resources: {}
         - name: check-registry

--- a/packs/rust/.lighthouse/jenkins-x/release.yaml
+++ b/packs/rust/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/rust/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -25,7 +24,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-cargo-install
           resources: {}
         - name: check-registry

--- a/packs/scala/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/scala/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/scala/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-sbt-assembly
           resources: {}
         - name: check-registry

--- a/packs/scala/.lighthouse/jenkins-x/release.yaml
+++ b/packs/scala/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/scala/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -25,7 +24,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-sbt-assembly
           resources: {}
         - name: check-registry

--- a/packs/terraform/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/terraform/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/terraform/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
         - name: lint
           resources: {}
   podTemplate: {}

--- a/packs/terraform/.lighthouse/jenkins-x/release.yaml
+++ b/packs/terraform/.lighthouse/jenkins-x/release.yaml
@@ -14,9 +14,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/terraform/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
@@ -25,7 +24,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
         - name: lint
           resources: {}
         - name: changelog

--- a/packs/typescript/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/typescript/.lighthouse/jenkins-x/pullrequest.yaml
@@ -14,16 +14,19 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/typescript/pullrequest.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
           name: ""
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-npm-install
           resources: {}
         - name: build-npm-test

--- a/packs/typescript/.lighthouse/jenkins-x/release.yaml
+++ b/packs/typescript/.lighthouse/jenkins-x/release.yaml
@@ -17,9 +17,8 @@ spec:
           image: uses:jenkins-x/jx3-pipeline-catalog/tasks/typescript/release.yaml@versionStream
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            # override limits for all containers here
+            limits: {}
           volumeMounts:
           - mountPath: /tekton/home/npm
             name: npmrc
@@ -31,7 +30,11 @@ spec:
         - name: next-version
           resources: {}
         - name: jx-variables
-          resources: {}
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - name: build-npm-install
           resources: {}
         - name: build-npm-test

--- a/tasks/D/pullrequest.yaml
+++ b/tasks/D/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 500m
-              memory: 1Gi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 500m
+              memory: 1Gi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/D/release.yaml
+++ b/tasks/D/release.yaml
@@ -20,9 +20,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 500m
-              memory: 1Gi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - env:
@@ -44,7 +42,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 500m
+              memory: 1Gi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/apps/pullrequest.yaml
+++ b/tasks/apps/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/apps/release.yaml
+++ b/tasks/apps/release.yaml
@@ -20,9 +20,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - env:
@@ -38,7 +36,11 @@ spec:
                 name: tekton-git
           image: ghcr.io/jenkins-x/jx-release-version:2.5.1
           name: next-version
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION

--- a/tasks/appserver/pullrequest.yaml
+++ b/tasks/appserver/pullrequest.yaml
@@ -28,14 +28,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/appserver/release.yaml
+++ b/tasks/appserver/release.yaml
@@ -28,9 +28,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - env:
@@ -52,7 +50,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/csharp/pullrequest.yaml
+++ b/tasks/csharp/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 200m
-              memory: 256Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 200m
+              memory: 256Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/csharp/release.yaml
+++ b/tasks/csharp/release.yaml
@@ -20,9 +20,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 200m
-              memory: 256Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - env:
@@ -44,7 +42,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 200m
+              memory: 256Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/custom-jenkins/pullrequest.yaml
+++ b/tasks/custom-jenkins/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/custom-jenkins/release.yaml
+++ b/tasks/custom-jenkins/release.yaml
@@ -20,9 +20,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - env:
@@ -38,7 +36,11 @@ spec:
                 name: tekton-git
           image: ghcr.io/jenkins-x/jx-release-version:2.5.1
           name: next-version
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION

--- a/tasks/cwp/pullrequest.yaml
+++ b/tasks/cwp/pullrequest.yaml
@@ -28,14 +28,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/cwp/release.yaml
+++ b/tasks/cwp/release.yaml
@@ -28,9 +28,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - env:
@@ -52,7 +50,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/docker-helm/pullrequest.yaml
+++ b/tasks/docker-helm/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/docker-helm/release.yaml
+++ b/tasks/docker-helm/release.yaml
@@ -20,9 +20,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - env:
@@ -44,7 +42,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/docker/pullrequest.yaml
+++ b/tasks/docker/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/docker/release.yaml
+++ b/tasks/docker/release.yaml
@@ -20,9 +20,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - env:
@@ -44,7 +42,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/environment/pullrequest.yaml
+++ b/tasks/environment/pullrequest.yaml
@@ -20,9 +20,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - args:
@@ -35,7 +33,10 @@ spec:
               optional: true
           image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: make-pr
-          resources: {}
+          resources:
+            requests:
+              cpu: 400m
+              memory: 512Mi
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/kubetest/environment.yaml@versionStream
           name: ""
           resources: {}

--- a/tasks/environment/release.yaml
+++ b/tasks/environment/release.yaml
@@ -20,14 +20,15 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-admin:0.0.174
           name: admin-log
-          resources: {}
+          resources:
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             echo "viewing the git operator boot job log for commit sha: $PULL_BASE_SHA"

--- a/tasks/flutter/pullrequest.yaml
+++ b/tasks/flutter/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/flutter/release.yaml
+++ b/tasks/flutter/release.yaml
@@ -22,9 +22,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           volumeMounts:
           - mountPath: /tekton/home/npm
             name: npmrc
@@ -49,7 +47,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/go-cli/pullrequest.yaml
+++ b/tasks/go-cli/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/go-cli/release.yaml
+++ b/tasks/go-cli/release.yaml
@@ -20,9 +20,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - env:
@@ -38,7 +36,11 @@ spec:
                 name: tekton-git
           image: ghcr.io/jenkins-x/jx-release-version:2.5.1
           name: next-version
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION

--- a/tasks/go-mongodb/pullrequest.yaml
+++ b/tasks/go-mongodb/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/go-mongodb/release.yaml
+++ b/tasks/go-mongodb/release.yaml
@@ -20,9 +20,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - env:
@@ -38,7 +36,11 @@ spec:
                 name: tekton-git
           image: ghcr.io/jenkins-x/jx-release-version:2.5.1
           name: next-version
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION

--- a/tasks/go-plugin-multiarch/pullrequest.yaml
+++ b/tasks/go-plugin-multiarch/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/go-plugin/pullrequest.yaml
+++ b/tasks/go-plugin/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/go/pullrequest.yaml
+++ b/tasks/go/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/go/release.yaml
+++ b/tasks/go/release.yaml
@@ -20,9 +20,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - env:
@@ -38,7 +36,11 @@ spec:
                 name: tekton-git
           image: ghcr.io/jenkins-x/jx-release-version:2.5.1
           name: next-version
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION

--- a/tasks/gradle/pullrequest.yaml
+++ b/tasks/gradle/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/gradle/release.yaml
+++ b/tasks/gradle/release.yaml
@@ -20,9 +20,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - env:
@@ -44,7 +42,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/helm/pullrequest.yaml
+++ b/tasks/helm/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/helm/release.yaml
+++ b/tasks/helm/release.yaml
@@ -20,9 +20,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - env:
@@ -44,7 +42,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/javascript-ui-nginx/pullrequest.yaml
+++ b/tasks/javascript-ui-nginx/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/javascript-ui-nginx/release.yaml
+++ b/tasks/javascript-ui-nginx/release.yaml
@@ -22,9 +22,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           volumeMounts:
           - mountPath: /tekton/home/npm
             name: npmrc
@@ -49,7 +47,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/javascript/pullrequest.yaml
+++ b/tasks/javascript/pullrequest.yaml
@@ -22,9 +22,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           volumeMounts:
           - mountPath: /tekton/home/npm
             name: npmrc
@@ -32,7 +30,11 @@ spec:
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/javascript/release.yaml
+++ b/tasks/javascript/release.yaml
@@ -22,9 +22,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           volumeMounts:
           - mountPath: /tekton/home/npm
             name: npmrc
@@ -49,7 +47,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/jenkins/pullrequest.yaml
+++ b/tasks/jenkins/pullrequest.yaml
@@ -28,14 +28,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/jenkins/release.yaml
+++ b/tasks/jenkins/release.yaml
@@ -28,9 +28,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - env:
@@ -52,7 +50,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/lint/lint.yaml
+++ b/tasks/lint/lint.yaml
@@ -12,9 +12,7 @@ spec:
       value: /tekton/home
     name: ""
     resources:
-      requests:
-        cpu: 400m
-        memory: 512Mi
+      limits: {}
     workingDir: /workspace/source
   steps:
   - env:
@@ -32,7 +30,10 @@ spec:
       value: "true"
     image: github/super-linter:v3.13.1
     name: lint
-    resources: {}
+    resources:
+      requests:
+        cpu: 400m
+        memory: 512Mi
   - image: ghcr.io/jenkins-x/jx-tap:0.0.14
     name: pr-comment
     resources: {}

--- a/tasks/lookml/lint.yaml
+++ b/tasks/lookml/lint.yaml
@@ -29,14 +29,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: $(workspaces.output.path)/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/lookml/pullrequest.yaml
+++ b/tasks/lookml/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables
@@ -39,7 +41,7 @@ spec:
             #!/bin/sh
             . .jx/variables.sh
             pip install spectacles
-            set -x 
+            set -x
             spectacles assert \
               --port 443 \
               --branch $PR_HEAD_REF \

--- a/tasks/lookml/release.yaml
+++ b/tasks/lookml/release.yaml
@@ -20,9 +20,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - env:
@@ -44,7 +42,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/maven-java11/pullrequest.yaml
+++ b/tasks/maven-java11/pullrequest.yaml
@@ -27,9 +27,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -37,7 +35,11 @@ spec:
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/maven-java11/release.yaml
+++ b/tasks/maven-java11/release.yaml
@@ -27,9 +27,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -56,7 +54,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/maven-java14/pullrequest.yaml
+++ b/tasks/maven-java14/pullrequest.yaml
@@ -23,9 +23,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -33,7 +31,11 @@ spec:
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/maven-java14/release.yaml
+++ b/tasks/maven-java14/release.yaml
@@ -23,9 +23,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -52,7 +50,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/maven-java16/pullrequest.yaml
+++ b/tasks/maven-java16/pullrequest.yaml
@@ -23,9 +23,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -33,7 +31,11 @@ spec:
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/maven-java16/release.yaml
+++ b/tasks/maven-java16/release.yaml
@@ -23,9 +23,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -52,7 +50,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/maven-java17/pullrequest.yaml
+++ b/tasks/maven-java17/pullrequest.yaml
@@ -23,9 +23,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -33,7 +31,11 @@ spec:
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/maven-java17/release.yaml
+++ b/tasks/maven-java17/release.yaml
@@ -23,9 +23,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -52,7 +50,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/maven-node-ruby/pullrequest.yaml
+++ b/tasks/maven-node-ruby/pullrequest.yaml
@@ -28,9 +28,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -38,7 +36,11 @@ spec:
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/maven-node-ruby/release.yaml
+++ b/tasks/maven-node-ruby/release.yaml
@@ -28,9 +28,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -57,7 +55,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/maven-quarkus-native/pullrequest.yaml
+++ b/tasks/maven-quarkus-native/pullrequest.yaml
@@ -27,9 +27,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 2Gi
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -37,7 +35,11 @@ spec:
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 2Gi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/maven-quarkus-native/release.yaml
+++ b/tasks/maven-quarkus-native/release.yaml
@@ -27,9 +27,9 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 2Gi
+            limits:
+              cpu: "12"
+              memory: "8Gi"
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -56,19 +56,17 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: "2"
+              memory: "4Gi"
           script: |
             #!/usr/bin/env sh
             jx gitops variables
         - image: ghcr.io/jenkins-x/maven-quarkus-mandrel:0.0.2
           name: build-mvn-deploy
           resources:
-            requests:
-              memory: "4Gi"
-              cpu: "2"
-            limits:
-              memory: "8Gi"
-              cpu: "12"
           script: |
             #!/usr/bin/env bash
             source .jx/variables.sh

--- a/tasks/maven-quarkus/pullrequest.yaml
+++ b/tasks/maven-quarkus/pullrequest.yaml
@@ -27,9 +27,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 2Gi
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -37,7 +35,11 @@ spec:
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 2Gi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/maven-quarkus/release.yaml
+++ b/tasks/maven-quarkus/release.yaml
@@ -27,9 +27,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 2Gi
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -56,7 +54,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 2Gi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/maven/pullrequest.yaml
+++ b/tasks/maven/pullrequest.yaml
@@ -28,9 +28,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -38,7 +36,11 @@ spec:
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/maven/release.yaml
+++ b/tasks/maven/release.yaml
@@ -28,9 +28,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           volumeMounts:
           - mountPath: /root/.m2/
             name: maven-settings
@@ -57,7 +55,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/ml-python-gpu-service/pullrequest.yaml
+++ b/tasks/ml-python-gpu-service/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: "1"
-              memory: 1Gi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: "1"
+              memory: 1Gi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/ml-python-gpu-service/release.yaml
+++ b/tasks/ml-python-gpu-service/release.yaml
@@ -20,9 +20,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: "1"
-              memory: 1Gi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - env:
@@ -44,7 +42,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: "1"
+              memory: 1Gi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/ml-python-gpu-training/pullrequest.yaml
+++ b/tasks/ml-python-gpu-training/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: "2"
-              memory: 4Gi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: "2"
+              memory: 4Gi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/ml-python-gpu-training/release.yaml
+++ b/tasks/ml-python-gpu-training/release.yaml
@@ -20,10 +20,6 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: "1"
-              memory: 4Gi
-              nvidia.com/gpu: 0
             limits:
               cpu: "1"
               memory: 4Gi
@@ -49,7 +45,12 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: "1"
+              memory: 4Gi
+              nvidia.com/gpu: 0
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/ml-python-service/pullrequest.yaml
+++ b/tasks/ml-python-service/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: "2"
-              memory: 4Gi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: "2"
+              memory: 4Gi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/ml-python-service/release.yaml
+++ b/tasks/ml-python-service/release.yaml
@@ -20,9 +20,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: "2"
-              memory: 4Gi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - env:
@@ -44,7 +42,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: "2"
+              memory: 4Gi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/ml-python-training/pullrequest.yaml
+++ b/tasks/ml-python-training/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: "2"
-              memory: 4Gi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: "2"
+              memory: 4Gi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/ml-python-training/release.yaml
+++ b/tasks/ml-python-training/release.yaml
@@ -20,9 +20,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: "2"
-              memory: 4Gi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - env:
@@ -44,7 +42,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: "2"
+              memory: 4Gi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/php/pullrequest.yaml
+++ b/tasks/php/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 200m
-              memory: 256Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 200m
+              memory: 256Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/php/release.yaml
+++ b/tasks/php/release.yaml
@@ -20,9 +20,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 200m
-              memory: 256Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - env:
@@ -44,7 +42,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 200m
+              memory: 256Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/python/pullrequest.yaml
+++ b/tasks/python/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/python/release.yaml
+++ b/tasks/python/release.yaml
@@ -20,9 +20,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - env:
@@ -44,7 +42,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/ruby/pullrequest.yaml
+++ b/tasks/ruby/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/ruby/release.yaml
+++ b/tasks/ruby/release.yaml
@@ -20,9 +20,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - env:
@@ -44,7 +42,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/rust/pullrequest.yaml
+++ b/tasks/rust/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/rust/release.yaml
+++ b/tasks/rust/release.yaml
@@ -20,9 +20,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - env:
@@ -44,7 +42,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/scala/pullrequest.yaml
+++ b/tasks/scala/pullrequest.yaml
@@ -28,14 +28,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/scala/release.yaml
+++ b/tasks/scala/release.yaml
@@ -28,9 +28,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - env:
@@ -52,7 +50,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/terraform/pullrequest.yaml
+++ b/tasks/terraform/pullrequest.yaml
@@ -20,14 +20,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/terraform/release.yaml
+++ b/tasks/terraform/release.yaml
@@ -20,9 +20,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 600Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - env:
@@ -38,7 +36,11 @@ spec:
                 name: tekton-git
           image: ghcr.io/jenkins-x/jx-release-version:2.5.1
           name: next-version
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 600Mi
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION

--- a/tasks/typescript/pullrequest.yaml
+++ b/tasks/typescript/pullrequest.yaml
@@ -22,14 +22,16 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           workingDir: /workspace/source
         steps:
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables

--- a/tasks/typescript/release.yaml
+++ b/tasks/typescript/release.yaml
@@ -22,9 +22,7 @@ spec:
               optional: true
           name: ""
           resources:
-            requests:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           volumeMounts:
           - mountPath: /tekton/home/npm
             name: npmrc
@@ -49,7 +47,11 @@ spec:
             jx-release-version --tag > VERSION
         - image: ghcr.io/jenkins-x/jx-boot:3.2.263
           name: jx-variables
-          resources: {}
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
           script: |
             #!/usr/bin/env sh
             jx gitops variables


### PR DESCRIPTION
Tekton previously modified step resource requests to request one large container (with the max resource request of any Step) and resource requests of 0 in all other containers. This behavior was modified in v0.28.0 (https://github.com/tektoncd/pipeline/pull/4176). Now, the Step resource requests are preserved. This results in increased cpu/memory requests that we don't need and subsequent pipelines stuck in a `pending` state due to cluster/node resource exhaustion.

I propose that we set the default requests in the most common tekton pipeline step (jx-variables) and provide comments/documentation that push the user to use this to set the mem/cpu requests for the entire tekton task (pod). Also, it makes most sense to me to establish the convention of setting limits in `stepTemplate` because users will most likely want to OOMkill or cpu throttle when **any** container in the pod goes over limits.
```yaml
  pipelineSpec:
    tasks:
    - name: from-build-pack
      resources: {}
      taskSpec:
        stepTemplate:
          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/typescript/pullrequest.yaml@versionStream
          name: ""
          resources:
            # override limits for all containers here
            limits: {}
```

https://github.com/cdfoundation/tekton-helm-chart/commit/a7e00179a035c7fe29c0683201a5907a5de9378f
https://github.com/tektoncd/pipeline/pull/4472