### PR TITLE
fix(go-cli): missing build-make-build step in release

### DIFF
--- a/packs/go-cli/.lighthouse/jenkins-x/release.yaml
+++ b/packs/go-cli/.lighthouse/jenkins-x/release.yaml
@@ -29,7 +29,7 @@ spec:
             requests:
               cpu: 400m
               memory: 600Mi
-        - name: build-make-build
+        - name: upload-binaries
           resources: {}
         - name: check-registry
           resources: {}


### PR DESCRIPTION
running `jx pipeline lint` against the packs folder results in this message
```
packs/go-cli/.lighthouse/jenkins-x/release.yaml                     failed to unmarshal YAML file packs/go-cli/.lighthouse/jenkins-x/release.yaml: failed to inherit steps: failed to process uses steps: failed to resolve git URI jenkins-x/jx3-pipeline-catalog/tasks/go-cli/release.yaml@versionStream for step build-make-build: failed to : source URI jenkins-x/jx3-pipeline-catalog/tasks/go-cli/release.yaml@versionStream task from-build-pack has no step named build-make-build
```
the `build-make-build` step in the go-cli release pipeline appears to have been renamed to `upload-binaries` in https://github.com/jenkins-x/jx3-pipeline-catalog/pull/762/files, but the pack was never updated. @rawlingsj am i reading the intent here correctly?

maybe we should lint the pipeline files on every PR https://github.com/jenkins-x/jx3-pipeline-catalog/pull/1285
related https://github.com/jenkins-x-plugins/jx-pipeline/issues/492