### PR TITLE
chore(nodejs): use v14 per v12 EOL

### DIFF
--- a/packs/javascript/Dockerfile
+++ b/packs/javascript/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-slim
+FROM node:14-slim
 ENV PORT 8080
 EXPOSE 8080
 WORKDIR /usr/src/app

--- a/packs/typescript/Dockerfile
+++ b/packs/typescript/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-slim
+FROM node:14-slim
 ENV PORT 8080
 EXPOSE 8080
 WORKDIR /usr/src/app

--- a/tasks/javascript-ui-nginx/pullrequest.yaml
+++ b/tasks/javascript-ui-nginx/pullrequest.yaml
@@ -32,19 +32,19 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: node:12-slim
+        - image: node:14-slim
           name: build-npm-install
           resources: {}
           script: |
             #!/bin/sh
             npm install
-        - image: node:12-slim
+        - image: node:14-slim
           name: build-npm-test
           resources: {}
           script: |
             #!/bin/sh
             CI=true DISPLAY=:99 npm test
-        - image: node:12-slim
+        - image: node:14-slim
           name: build-ui-build
           resources: {}
           script: |

--- a/tasks/javascript-ui-nginx/release.yaml
+++ b/tasks/javascript-ui-nginx/release.yaml
@@ -53,19 +53,19 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: node:12-slim
+        - image: node:14-slim
           name: build-npm-install
           resources: {}
           script: |
             #!/bin/sh
             npm install
-        - image: node:12-slim
+        - image: node:14-slim
           name: build-npm-test
           resources: {}
           script: |
             #!/bin/sh
             CI=true DISPLAY=:99 npm test
-        - image: node:12-slim
+        - image: node:14-slim
           name: build-ui-build
           resources: {}
           script: |

--- a/tasks/javascript/pullrequest.yaml
+++ b/tasks/javascript/pullrequest.yaml
@@ -37,13 +37,13 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: node:12-slim
+        - image: node:14-slim
           name: build-npm-install
           resources: {}
           script: |
             #!/bin/sh
             npm install
-        - image: node:12-slim
+        - image: node:14-slim
           name: build-npm-test
           resources: {}
           script: |

--- a/tasks/javascript/release.yaml
+++ b/tasks/javascript/release.yaml
@@ -53,13 +53,13 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: node:12-slim
+        - image: node:14-slim
           name: build-npm-install
           resources: {}
           script: |
             #!/bin/sh
             npm install
-        - image: node:12-slim
+        - image: node:14-slim
           name: build-npm-test
           resources: {}
           script: |

--- a/tasks/lookml/lint.yaml
+++ b/tasks/lookml/lint.yaml
@@ -41,7 +41,7 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: node:12-slim
+        - image: node:14-slim
           name: build-lookml-lint
           resources: {}
           script: |

--- a/tasks/typescript/pullrequest.yaml
+++ b/tasks/typescript/pullrequest.yaml
@@ -34,13 +34,13 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: node:12-slim
+        - image: node:14-slim
           name: build-npm-install
           resources: {}
           script: |
             #!/bin/sh
             npm install
-        - image: node:12-slim
+        - image: node:14-slim
           name: build-npm-test
           resources: {}
           script: |

--- a/tasks/typescript/release.yaml
+++ b/tasks/typescript/release.yaml
@@ -53,13 +53,13 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: node:12-slim
+        - image: node:14-slim
           name: build-npm-install
           resources: {}
           script: |
             #!/bin/sh
             npm install
-        - image: node:12-slim
+        - image: node:14-slim
           name: build-npm-test
           resources: {}
           script: |


### PR DESCRIPTION
NodeJS v12 Security Support ends 4/30/2022
@see https://endoflife.date/nodejs

Resolves: #1021
Signed-off-by: Hays Clark <hays.clark@gmail.com>