### PR TITLE
fix: increase time out for goreleaser

### DIFF
--- a/tasks/go-plugin/release.yaml
+++ b/tasks/go-plugin/release.yaml
@@ -113,7 +113,7 @@ spec:
             export REV=$(git rev-parse HEAD)
             export GOVERSION="1.17.9"
             export ROOTPACKAGE="github.com/$REPO_OWNER/$REPO_NAME"
-            goreleaser release --timeout 1h
+            goreleaser release --timeout 2h
         - command:
           - jx-updatebot
           - pr


### PR DESCRIPTION
At least for jx-gitops goreleaser frequently times out, so an increase seems reasonable