### PR TITLE
fix:  compatible more authentication method for docker

### DIFF
--- a/tasks/C++/pullrequest.yaml
+++ b/tasks/C++/pullrequest.yaml
@@ -50,7 +50,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/C++/release.yaml
+++ b/tasks/C++/release.yaml
@@ -66,7 +66,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/D/pullrequest.yaml
+++ b/tasks/D/pullrequest.yaml
@@ -49,7 +49,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/D/release.yaml
+++ b/tasks/D/release.yaml
@@ -65,7 +65,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/appserver/pullrequest.yaml
+++ b/tasks/appserver/pullrequest.yaml
@@ -64,7 +64,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/appserver/release.yaml
+++ b/tasks/appserver/release.yaml
@@ -73,7 +73,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/build-scan-push/build-scan-push.yaml
+++ b/tasks/build-scan-push/build-scan-push.yaml
@@ -22,7 +22,7 @@ spec:
     script: |
       #!/busybox/sh
       source .jx/variables.sh
-      cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+      cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
       /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION --no-push --tarPath image.tar
       cp /kaniko/docker-credential-gcr /workspace/source
       cp /kaniko/docker-credential-ecr-login /workspace/source

--- a/tasks/csharp/pullrequest.yaml
+++ b/tasks/csharp/pullrequest.yaml
@@ -43,7 +43,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/csharp/release.yaml
+++ b/tasks/csharp/release.yaml
@@ -59,7 +59,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/cwp/pullrequest.yaml
+++ b/tasks/cwp/pullrequest.yaml
@@ -64,7 +64,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/cwp/release.yaml
+++ b/tasks/cwp/release.yaml
@@ -95,7 +95,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/docker-helm/pullrequest.yaml
+++ b/tasks/docker-helm/pullrequest.yaml
@@ -43,7 +43,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
   podTemplate: {}
   serviceAccountName: tekton-bot

--- a/tasks/docker-helm/release.yaml
+++ b/tasks/docker-helm/release.yaml
@@ -59,7 +59,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/docker/pullrequest.yaml
+++ b/tasks/docker/pullrequest.yaml
@@ -43,7 +43,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
   podTemplate: {}
   serviceAccountName: tekton-bot

--- a/tasks/docker/release.yaml
+++ b/tasks/docker/release.yaml
@@ -59,7 +59,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/go-cli/pullrequest.yaml
+++ b/tasks/go-cli/pullrequest.yaml
@@ -55,7 +55,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
   podTemplate: {}
   serviceAccountName: tekton-bot

--- a/tasks/go-cli/release.yaml
+++ b/tasks/go-cli/release.yaml
@@ -84,7 +84,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
   podTemplate: {}
   serviceAccountName: tekton-bot

--- a/tasks/go-mongodb/pullrequest.yaml
+++ b/tasks/go-mongodb/pullrequest.yaml
@@ -49,7 +49,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/go-mongodb/release.yaml
+++ b/tasks/go-mongodb/release.yaml
@@ -65,7 +65,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/go-plugin-multiarch/pullrequest.yaml
+++ b/tasks/go-plugin-multiarch/pullrequest.yaml
@@ -61,7 +61,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$REPO_NAME:$VERSION
   podTemplate: {}
   serviceAccountName: tekton-bot

--- a/tasks/go-plugin-multiarch/release.yaml
+++ b/tasks/go-plugin-multiarch/release.yaml
@@ -58,7 +58,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=gcr.io/$DOCKER_REGISTRY_ORG/$REPO_NAME:$VERSION --destination=gcr.io/$DOCKER_REGISTRY_ORG/$REPO_NAME:latest
         - image: jnorwood/helm-docs:v1.4.0
           name: chart-docs

--- a/tasks/go-plugin/pullrequest.yaml
+++ b/tasks/go-plugin/pullrequest.yaml
@@ -61,7 +61,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$REPO_NAME:$VERSION
   podTemplate: {}
   serviceAccountName: tekton-bot

--- a/tasks/go-plugin/release.yaml
+++ b/tasks/go-plugin/release.yaml
@@ -58,7 +58,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=ghcr.io/$DOCKER_REGISTRY_ORG/$REPO_NAME:$VERSION --destination=ghcr.io/$DOCKER_REGISTRY_ORG/$REPO_NAME:latest
         - image: jnorwood/helm-docs:v1.4.0
           name: chart-docs

--- a/tasks/go/pullrequest.yaml
+++ b/tasks/go/pullrequest.yaml
@@ -55,7 +55,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/go/release.yaml
+++ b/tasks/go/release.yaml
@@ -65,7 +65,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/gradle/pullrequest.yaml
+++ b/tasks/gradle/pullrequest.yaml
@@ -49,7 +49,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/gradle/release.yaml
+++ b/tasks/gradle/release.yaml
@@ -65,7 +65,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/javascript-ui-nginx/pullrequest.yaml
+++ b/tasks/javascript-ui-nginx/pullrequest.yaml
@@ -61,7 +61,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/javascript-ui-nginx/release.yaml
+++ b/tasks/javascript-ui-nginx/release.yaml
@@ -82,7 +82,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/javascript/pullrequest.yaml
+++ b/tasks/javascript/pullrequest.yaml
@@ -60,7 +60,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/javascript/release.yaml
+++ b/tasks/javascript/release.yaml
@@ -76,7 +76,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/jenkins/pullrequest.yaml
+++ b/tasks/jenkins/pullrequest.yaml
@@ -51,7 +51,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
   podTemplate: {}
   serviceAccountName: tekton-bot

--- a/tasks/jenkins/release.yaml
+++ b/tasks/jenkins/release.yaml
@@ -67,7 +67,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/maven-java11/pullrequest.yaml
+++ b/tasks/maven-java11/pullrequest.yaml
@@ -66,7 +66,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/maven-java11/release.yaml
+++ b/tasks/maven-java11/release.yaml
@@ -83,7 +83,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/maven-java14/pullrequest.yaml
+++ b/tasks/maven-java14/pullrequest.yaml
@@ -62,7 +62,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/maven-java14/release.yaml
+++ b/tasks/maven-java14/release.yaml
@@ -79,7 +79,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/maven-java16/pullrequest.yaml
+++ b/tasks/maven-java16/pullrequest.yaml
@@ -62,7 +62,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/maven-java16/release.yaml
+++ b/tasks/maven-java16/release.yaml
@@ -79,7 +79,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/maven-java17/pullrequest.yaml
+++ b/tasks/maven-java17/pullrequest.yaml
@@ -62,7 +62,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/maven-java17/release.yaml
+++ b/tasks/maven-java17/release.yaml
@@ -91,7 +91,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/maven-node-ruby/pullrequest.yaml
+++ b/tasks/maven-node-ruby/pullrequest.yaml
@@ -68,7 +68,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/maven-node-ruby/release.yaml
+++ b/tasks/maven-node-ruby/release.yaml
@@ -84,7 +84,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/maven-quarkus-native/pullrequest.yaml
+++ b/tasks/maven-quarkus-native/pullrequest.yaml
@@ -66,7 +66,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/maven-quarkus-native/release.yaml
+++ b/tasks/maven-quarkus-native/release.yaml
@@ -82,7 +82,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/maven-quarkus/pullrequest.yaml
+++ b/tasks/maven-quarkus/pullrequest.yaml
@@ -66,7 +66,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/maven-quarkus/release.yaml
+++ b/tasks/maven-quarkus/release.yaml
@@ -83,7 +83,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/maven/pullrequest.yaml
+++ b/tasks/maven/pullrequest.yaml
@@ -67,7 +67,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/maven/release.yaml
+++ b/tasks/maven/release.yaml
@@ -84,7 +84,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/ml-python-gpu-service/pullrequest.yaml
+++ b/tasks/ml-python-gpu-service/pullrequest.yaml
@@ -65,7 +65,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/ml-python-gpu-service/release.yaml
+++ b/tasks/ml-python-gpu-service/release.yaml
@@ -80,7 +80,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/ml-python-service/pullrequest.yaml
+++ b/tasks/ml-python-service/pullrequest.yaml
@@ -65,7 +65,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/ml-python-service/release.yaml
+++ b/tasks/ml-python-service/release.yaml
@@ -80,7 +80,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/php/pullrequest.yaml
+++ b/tasks/php/pullrequest.yaml
@@ -43,7 +43,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/php/release.yaml
+++ b/tasks/php/release.yaml
@@ -59,7 +59,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/python/pullrequest.yaml
+++ b/tasks/python/pullrequest.yaml
@@ -49,7 +49,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/python/release.yaml
+++ b/tasks/python/release.yaml
@@ -65,7 +65,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/ruby/pullrequest.yaml
+++ b/tasks/ruby/pullrequest.yaml
@@ -43,7 +43,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/ruby/release.yaml
+++ b/tasks/ruby/release.yaml
@@ -59,7 +59,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/rust/pullrequest.yaml
+++ b/tasks/rust/pullrequest.yaml
@@ -49,7 +49,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/rust/release.yaml
+++ b/tasks/rust/release.yaml
@@ -65,7 +65,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/scala/pullrequest.yaml
+++ b/tasks/scala/pullrequest.yaml
@@ -57,7 +57,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/scala/release.yaml
+++ b/tasks/scala/release.yaml
@@ -73,7 +73,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog

--- a/tasks/typescript/pullrequest.yaml
+++ b/tasks/typescript/pullrequest.yaml
@@ -57,7 +57,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.221
           name: promote-jx-preview

--- a/tasks/typescript/release.yaml
+++ b/tasks/typescript/release.yaml
@@ -76,7 +76,7 @@ spec:
           script: |
             #!/busybox/sh
             source .jx/variables.sh
-            cp /tekton/creds-secrets/tekton-container-registry-auth/.dockerconfigjson /kaniko/.docker/config.json
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
         - image: ghcr.io/jenkins-x/jx-changelog:0.3.0
           name: promote-changelog


### PR DESCRIPTION
as https://tekton.dev/docs/pipelines/auth/#configuring-docker-authentication-for-docker
Docker authentication should be used in a more compatible way, rather than using only fixed tokens