### PR TITLE
Javascript pack fix pr 984

### DIFF
--- a/packs/javascript/.lighthouse/jenkins-x/release.yaml
+++ b/packs/javascript/.lighthouse/jenkins-x/release.yaml
@@ -14,13 +14,11 @@ spec:
           env:
           - name: NPM_CONFIG_USERCONFIG
             value: /tekton/home/npm/.npmrc
-          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/javascript/release.yaml@versionStream
+          image: uses:LFS268-laucapgemini/jx3-pipeline-catalog/tasks/javascript/release.yaml@versionStream
           name: ""
           resources:
             # override limits for all containers here
-            limits:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
           volumeMounts:
           - mountPath: /tekton/home/npm
             name: npmrc
@@ -35,8 +33,8 @@ spec:
           resources:
             # override requests for the pod here
             requests:
-              cpu: 0.1
-              memory: 128Mi
+              cpu: 400m
+              memory: 512Mi
         - name: build-npm-install
           resources: {}
         - name: build-npm-test

--- a/packs/javascript/.lighthouse/jenkins-x/release.yaml
+++ b/packs/javascript/.lighthouse/jenkins-x/release.yaml
@@ -14,7 +14,7 @@ spec:
           env:
           - name: NPM_CONFIG_USERCONFIG
             value: /tekton/home/npm/.npmrc
-          image: uses:LFS268-laucapgemini/jx3-pipeline-catalog/tasks/javascript/release.yaml@versionStream
+          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/javascript/release.yaml@versionStream
           name: ""
           resources:
             # override limits for all containers here


### PR DESCRIPTION
currently the javascript pack does not work : the release pipeline pod remains pending with a message stating that the CPU is not available in the cluster.

```
k get pods
NAME                                                              READY   STATUS      RESTARTS   AGE
myrepo-node-lab3-main-release-7cs56-from-build-pack-m6-bn42f   0/10    Pending     0          40m
...
---
k describe pod myrepo-node-lab3-main-release-7cs56-from-build-pack-m6-bn42f
...
  Warning  FailedScheduling   56s (x12 over 9m45s)    default-scheduler   0/3 nodes are available: 3 Insufficient cpu
```

I have tested my fix proposal that works well, and consistent with the PR https://github.com/jenkins-x/jx3-pipeline-catalog/pull/984 and the associated note in Jenkins-x blog site : https://jenkins-x.io/blog/2022/04/22/kubernetes-1.22-tekton/