### PR TITLE
fix: upgrade go to the latest go1.18 minor version

### DIFF
--- a/tasks/go-cli/pullrequest.yaml
+++ b/tasks/go-cli/pullrequest.yaml
@@ -34,13 +34,13 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: golang:1.18.4
+        - image: golang:1.18.6
           name: build-make-linux
           resources: {}
           script: |
             #!/bin/sh
             make linux
-        - image: golang:1.18.4
+        - image: golang:1.18.6
           name: build-make-test
           resources: {}
           script: |

--- a/tasks/go-mongodb/pullrequest.yaml
+++ b/tasks/go-mongodb/pullrequest.yaml
@@ -34,7 +34,7 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: golang:1.18.4
+        - image: golang:1.18.6
           name: build-make-linux
           resources: {}
           script: |

--- a/tasks/go-mongodb/release.yaml
+++ b/tasks/go-mongodb/release.yaml
@@ -50,7 +50,7 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: golang:1.18.4
+        - image: golang:1.18.6
           name: build-make-build
           resources: {}
           script: |

--- a/tasks/go-plugin-multiarch/pullrequest.yaml
+++ b/tasks/go-plugin-multiarch/pullrequest.yaml
@@ -34,7 +34,7 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: golang:1.18.4
+        - image: golang:1.18.6
           name: build-make-linux
           resources: {}
           script: |
@@ -46,7 +46,7 @@ spec:
           script: |
             #!/bin/sh
             golangci-lint run
-        - image: golang:1.18.4
+        - image: golang:1.18.6
           name: build-make-test
           resources: {}
           script: |

--- a/tasks/go-plugin-multiarch/release.yaml
+++ b/tasks/go-plugin-multiarch/release.yaml
@@ -45,7 +45,7 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: golang:1.18.4
+        - image: golang:1.18.6
           name: release-binary
           resources: {}
           script: |

--- a/tasks/go-plugin/pullrequest.yaml
+++ b/tasks/go-plugin/pullrequest.yaml
@@ -34,7 +34,7 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: golang:1.18.4
+        - image: golang:1.18.6
           name: build-make-linux
           resources: {}
           script: |
@@ -46,7 +46,7 @@ spec:
           script: |
             #!/bin/sh
             golangci-lint run --deadline 30m0s
-        - image: golang:1.18.4
+        - image: golang:1.18.6
           name: build-make-test
           resources: {}
           script: |

--- a/tasks/go-plugin/release.yaml
+++ b/tasks/go-plugin/release.yaml
@@ -45,7 +45,7 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: golang:1.18.4
+        - image: golang:1.18.6
           name: release-binary
           resources: {}
           script: |

--- a/tasks/go/pullrequest.yaml
+++ b/tasks/go/pullrequest.yaml
@@ -34,7 +34,7 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: golang:1.18.4
+        - image: golang:1.18.6
           name: build-make-linux
           resources: {}
           script: |

--- a/tasks/go/release.yaml
+++ b/tasks/go/release.yaml
@@ -50,7 +50,7 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: golang:1.18.4
+        - image: golang:1.18.6
           name: build-make-build
           resources: {}
           script: |


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

From go release notes:
```
go1.18.6 (released 2022-09-06) includes security fixes to the net/http package, as well as bug fixes to the compiler, the go command, the pprof command, the runtime, and the crypto/tls, encoding/xml, and net packages
```