### PR TITLE
fix: configure workspace mountPath to avoid permissions issues

### DIFF
--- a/packs/lookml/.lighthouse/jenkins-x/lint.yaml
+++ b/packs/lookml/.lighthouse/jenkins-x/lint.yaml
@@ -46,6 +46,7 @@ spec:
       taskSpec:
         workspaces:
           - name: output
+            mountPath: /workspace
         metadata: {}
         stepTemplate:
           env:

--- a/packs/lookml/.lighthouse/jenkins-x/lint.yaml
+++ b/packs/lookml/.lighthouse/jenkins-x/lint.yaml
@@ -43,31 +43,14 @@ spec:
       workspaces:
       - name: output
         workspace: output
-      params:
-      - name: PULL_NUMBER
-        value: $(params.PULL_NUMBER)
-      - name: REPO_URL
-        value: $(params.REPO_URL)
       taskSpec:
         workspaces:
           - name: output
         metadata: {}
-        params:
-        - default: ""
-          description: git pull request number
-          name: PULL_NUMBER
-          type: string
-        - description: git url to clone
-          name: REPO_URL
-          type: string
         stepTemplate:
           env:
           - name: HOME
             value: /tekton/home
-          - name: PULL_NUMBER
-            value: $(params.PULL_NUMBER)
-          - name: REPO_URL
-            value: $(params.REPO_URL)
           name: ""
           workingDir: $(workspaces.output.path)/source
         steps:

--- a/tasks/lookml/lint.yaml
+++ b/tasks/lookml/lint.yaml
@@ -16,6 +16,7 @@ spec:
       taskSpec:
         workspaces:
         - name: output
+          mountPath: /workspace
         metadata: {}
         stepTemplate:
           env:


### PR DESCRIPTION
today, our lookml lint pipeline that uses a custom pvc workspace started erroring out during the `git-merge` step with
```
fatal: detected dubious ownership in repository at '/workspace/source'
```

i believe it's due to the interaction between 

- the git clone step creating a `/workspace/source` directory https://github.com/jenkins-x/jx3-pipeline-catalog/blob/0c8876f333fa7f392be199ad72749a985ed02e84/tasks/git-clone/git-clone-pr.yaml#L33
- the hardcoded working dir https://github.com/jenkins-x/jx3-pipeline-catalog/blob/0c8876f333fa7f392be199ad72749a985ed02e84/tasks/git-clone/git-clone-pr.yaml#L39
- and the default tekton workspace mount behavior
  > If a mountPath is not provided the workspace will be placed by default at /workspace/<name> where <name> is the workspace’s unique name.

ex: 
i ran a `kubectl describe` against the lookml lint pipeline pod, and it looks like the

```
    Mounts:
    ...
      /workspace from tekton-internal-workspace (rw)
      /workspace/output from ws-5kn65 (rw)
```

with my updated PR, the pvc workspace **replaces** the default workspace instead mounting `/workspace/output` onto ` /workspace`
```
    Mounts:
    ...
      /workspace from ws-5kn65 (rw)
```