### PR TITLE
fix: prevent download of jx changelog and gitops

### DIFF
--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -31,7 +31,7 @@ spec:
               memory: 600Mi
         - name: promote-changelog
           resources: {}
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-pullrequest
           resources: {}
           script: |

--- a/tasks/C++/release.yaml
+++ b/tasks/C++/release.yaml
@@ -68,7 +68,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/D/release.yaml
+++ b/tasks/D/release.yaml
@@ -67,7 +67,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/appserver/release.yaml
+++ b/tasks/appserver/release.yaml
@@ -75,7 +75,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/csharp/release.yaml
+++ b/tasks/csharp/release.yaml
@@ -61,7 +61,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/cwp/release.yaml
+++ b/tasks/cwp/release.yaml
@@ -97,7 +97,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/docker-helm/release.yaml
+++ b/tasks/docker-helm/release.yaml
@@ -61,7 +61,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/docker/release.yaml
+++ b/tasks/docker/release.yaml
@@ -61,7 +61,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/flutter/release.yaml
+++ b/tasks/flutter/release.yaml
@@ -63,7 +63,7 @@ spec:
             flutter pub get
             flutter test
             flutter build apk
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/go-mongodb/release.yaml
+++ b/tasks/go-mongodb/release.yaml
@@ -67,7 +67,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/go-plugin-multiarch/release.yaml
+++ b/tasks/go-plugin-multiarch/release.yaml
@@ -67,7 +67,7 @@ spec:
             #!/bin/ash
             if [ -d "charts/$REPO_NAME" ]; then cd charts/$REPO_NAME
             helm-docs; else echo no charts; fi
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: changelog
           resources: {}
           script: |

--- a/tasks/go-plugin/release.yaml
+++ b/tasks/go-plugin/release.yaml
@@ -67,7 +67,7 @@ spec:
             #!/bin/ash
             if [ -d "charts/$REPO_NAME" ]; then cd charts/$REPO_NAME
             helm-docs; else echo no charts; fi
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: changelog
           resources: {}
           script: |

--- a/tasks/go/release.yaml
+++ b/tasks/go/release.yaml
@@ -67,7 +67,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/gradle/release.yaml
+++ b/tasks/gradle/release.yaml
@@ -67,7 +67,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/helm/release.yaml
+++ b/tasks/helm/release.yaml
@@ -50,7 +50,7 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/javascript-ui-nginx/release.yaml
+++ b/tasks/javascript-ui-nginx/release.yaml
@@ -84,7 +84,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/javascript/release.yaml
+++ b/tasks/javascript/release.yaml
@@ -78,7 +78,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/jenkins/release.yaml
+++ b/tasks/jenkins/release.yaml
@@ -69,7 +69,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/lookml/release.yaml
+++ b/tasks/lookml/release.yaml
@@ -50,7 +50,7 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/maven-java11/release.yaml
+++ b/tasks/maven-java11/release.yaml
@@ -85,7 +85,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/maven-java14/release.yaml
+++ b/tasks/maven-java14/release.yaml
@@ -81,7 +81,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/maven-java16/release.yaml
+++ b/tasks/maven-java16/release.yaml
@@ -81,7 +81,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/maven-java17/release.yaml
+++ b/tasks/maven-java17/release.yaml
@@ -93,7 +93,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/maven-node-ruby/release.yaml
+++ b/tasks/maven-node-ruby/release.yaml
@@ -86,7 +86,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/maven-quarkus-native/release.yaml
+++ b/tasks/maven-quarkus-native/release.yaml
@@ -84,7 +84,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/maven-quarkus/release.yaml
+++ b/tasks/maven-quarkus/release.yaml
@@ -85,7 +85,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/maven/release.yaml
+++ b/tasks/maven/release.yaml
@@ -86,7 +86,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/ml-python-gpu-service/release.yaml
+++ b/tasks/ml-python-gpu-service/release.yaml
@@ -82,7 +82,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/ml-python-service/release.yaml
+++ b/tasks/ml-python-service/release.yaml
@@ -82,7 +82,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/php/release.yaml
+++ b/tasks/php/release.yaml
@@ -61,7 +61,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/python/release.yaml
+++ b/tasks/python/release.yaml
@@ -67,7 +67,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/ruby/release.yaml
+++ b/tasks/ruby/release.yaml
@@ -61,7 +61,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/rust/release.yaml
+++ b/tasks/rust/release.yaml
@@ -67,7 +67,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/scala/release.yaml
+++ b/tasks/scala/release.yaml
@@ -75,7 +75,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |

--- a/tasks/terraform/release.yaml
+++ b/tasks/terraform/release.yaml
@@ -58,7 +58,7 @@ spec:
             terraform init
             terraform version
             terraform validate
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: changelog
           resources: {}
           script: |

--- a/tasks/typescript/release.yaml
+++ b/tasks/typescript/release.yaml
@@ -78,7 +78,7 @@ spec:
             source .jx/variables.sh
             cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
             /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
-        - image: ghcr.io/jenkins-x/jx-changelog:0.9.0
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.33
           name: promote-changelog
           resources: {}
           script: |


### PR DESCRIPTION
since jx-boot now includes jx changelog it can be used instead