### PR TITLE
skip header in plugin release notes

### DIFF
--- a/tasks/go-plugin-multiarch/release.yaml
+++ b/tasks/go-plugin-multiarch/release.yaml
@@ -81,7 +81,7 @@ spec:
             jx gitops yset -p 'image.tag' -v "$VERSION" -f ./charts/$REPO_NAME/values.yaml;
             else echo no charts; fi
 
-            jx changelog create --verbose --header-file=hack/changelog-header.md --version=$VERSION --rev=$PULL_BASE_SHA --output-markdown=changelog.md --update-release=true
+            jx changelog create --verbose --version=$VERSION --rev=$PULL_BASE_SHA --output-markdown=changelog.md --update-release=true
         - image: ghcr.io/jenkins-x/jx-boot:3.10.45
           name: release-chart
           resources: {}

--- a/tasks/go-plugin/release.yaml
+++ b/tasks/go-plugin/release.yaml
@@ -81,7 +81,7 @@ spec:
             jx gitops yset -p 'image.tag' -v "$VERSION" -f ./charts/$REPO_NAME/values.yaml;
             else echo no charts; fi
 
-            jx changelog create --verbose --header-file=hack/changelog-header.md --version=$VERSION --rev=$PULL_BASE_SHA --output-markdown=changelog.md --update-release=true
+            jx changelog create --verbose --version=$VERSION --rev=$PULL_BASE_SHA --output-markdown=changelog.md --update-release=true
         - image: ghcr.io/jenkins-x/jx-boot:3.10.45
           name: release-chart
           resources: {}


### PR DESCRIPTION
As far as I have seen this header is always an installation instruction  which isn't needed since the jx command will install plugins on demand.

Another problem is that the header clutters [the release notes of jx](https://github.com/jenkins-x/jx/releases) if it is propagated there.