### PR TITLE
Add Javascript-yarn task and pack

### DIFF
--- a/packs/javascript-yarn/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/javascript-yarn/.lighthouse/jenkins-x/pullrequest.yaml
@@ -1,0 +1,43 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  name: pullrequest
+spec:
+  pipelineSpec:
+    tasks:
+    - name: from-build-pack
+      resources: {}
+      taskSpec:
+        metadata: {}
+        stepTemplate:
+          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/javascript/pullrequest.yaml@versionStream
+          name: ""
+          resources:
+            # override limits for all containers here
+            limits: {}
+          workingDir: /workspace/source
+        steps:
+        - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
+          name: ""
+          resources: {}
+        - name: jx-variables
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 0.1
+              memory: 128Mi
+        - name: build-npm-install
+          resources: {}
+        - name: build-npm-test
+          resources: {}
+        - name: check-registry
+          resources: {}
+        - name: build-container-build
+          resources: {}
+        - name: promote-jx-preview
+          resources: {}
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 12h0m0s
+status: {}

--- a/packs/javascript-yarn/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/packs/javascript-yarn/.lighthouse/jenkins-x/pullrequest.yaml
@@ -11,7 +11,7 @@ spec:
       taskSpec:
         metadata: {}
         stepTemplate:
-          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/javascript/pullrequest.yaml@versionStream
+          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/javascript-yarn/pullrequest.yaml@versionStream
           name: ""
           resources:
             # override limits for all containers here
@@ -27,9 +27,9 @@ spec:
             requests:
               cpu: 0.1
               memory: 128Mi
-        - name: build-npm-install
+        - name: build-yarn-install
           resources: {}
-        - name: build-npm-test
+        - name: build-yarn-test
           resources: {}
         - name: check-registry
           resources: {}

--- a/packs/javascript-yarn/.lighthouse/jenkins-x/release.yaml
+++ b/packs/javascript-yarn/.lighthouse/jenkins-x/release.yaml
@@ -1,0 +1,60 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  name: release
+spec:
+  pipelineSpec:
+    tasks:
+    - name: from-build-pack
+      resources: {}
+      taskSpec:
+        metadata: {}
+        stepTemplate:
+          env:
+          - name: NPM_CONFIG_USERCONFIG
+            value: /tekton/home/npm/.npmrc
+          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/javascript/release.yaml@versionStream
+          name: ""
+          resources:
+            # override limits for all containers here
+            limits: {}
+          volumeMounts:
+          - mountPath: /tekton/home/npm
+            name: npmrc
+          workingDir: /workspace/source
+        steps:
+        - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone.yaml@versionStream
+          name: ""
+          resources: {}
+        - name: next-version
+          resources: {}
+        - name: jx-variables
+          resources:
+            # override requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
+        - name: build-npm-install
+          resources: {}
+        - name: build-npm-test
+          resources: {}
+        - name: check-registry
+          resources: {}
+        - name: build-container-build
+          resources: {}
+        - name: promote-changelog
+          resources: {}
+        - name: promote-helm-release
+          resources: {}
+        - name: promote-jx-promote
+          resources: {}
+        volumes:
+        - name: npmrc
+          secret:
+            optional: true
+            secretName: npmrc
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 12h0m0s
+status: {}

--- a/packs/javascript-yarn/.lighthouse/jenkins-x/release.yaml
+++ b/packs/javascript-yarn/.lighthouse/jenkins-x/release.yaml
@@ -14,7 +14,7 @@ spec:
           env:
           - name: NPM_CONFIG_USERCONFIG
             value: /tekton/home/npm/.npmrc
-          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/javascript/release.yaml@versionStream
+          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/javascript-yarn/release.yaml@versionStream
           name: ""
           resources:
             # override limits for all containers here
@@ -35,9 +35,9 @@ spec:
             requests:
               cpu: 400m
               memory: 512Mi
-        - name: build-npm-install
+        - name: build-yarn-install
           resources: {}
-        - name: build-npm-test
+        - name: build-yarn-test
           resources: {}
         - name: check-registry
           resources: {}

--- a/packs/javascript-yarn/.lighthouse/jenkins-x/triggers.yaml
+++ b/packs/javascript-yarn/.lighthouse/jenkins-x/triggers.yaml
@@ -1,0 +1,16 @@
+apiVersion: config.lighthouse.jenkins-x.io/v1alpha1
+kind: TriggerConfig
+spec:
+  presubmits:
+  - name: pr
+    context: "pr"
+    always_run: true
+    optional: false
+    source: "pullrequest.yaml"
+  postsubmits:
+  - name: release
+    context: "release"
+    source: "release.yaml"
+    branches:
+    - ^main$
+    - ^master$

--- a/packs/javascript-yarn/Dockerfile
+++ b/packs/javascript-yarn/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:14-slim
+ENV PORT 8080
+EXPOSE 8080
+WORKDIR /usr/src/app
+COPY . .
+CMD ["npm", "start"]

--- a/packs/javascript-yarn/charts/.helmignore
+++ b/packs/javascript-yarn/charts/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/packs/javascript-yarn/charts/Chart.yaml
+++ b/packs/javascript-yarn/charts/Chart.yaml
@@ -1,0 +1,5 @@
+name: REPLACE_ME_APP_NAME
+description: A Helm chart for Kubernetes
+apiVersion: v1
+version: 0.1.0-SNAPSHOT
+icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png

--- a/packs/javascript-yarn/charts/Kptfile
+++ b/packs/javascript-yarn/charts/Kptfile
@@ -1,0 +1,11 @@
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: charts
+upstream:
+  type: git
+  git:
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master

--- a/packs/javascript-yarn/charts/Makefile
+++ b/packs/javascript-yarn/charts/Makefile
@@ -1,0 +1,48 @@
+CHART_REPO := http://jenkins-x-chartmuseum:8080
+CURRENT=$(pwd)
+NAME := REPLACE_ME_APP_NAME
+OS := $(shell uname)
+RELEASE_VERSION := $(shell cat ../../VERSION)
+
+build: clean
+	rm -rf requirements.lock
+	helm dependency build
+	helm lint
+
+install: clean build
+	helm install . --name ${NAME}
+
+upgrade: clean build
+	helm upgrade ${NAME} .
+
+delete:
+	helm delete --purge ${NAME}
+
+clean:
+	rm -rf charts
+	rm -rf ${NAME}*.tgz
+
+release: clean
+	helm dependency build
+	helm lint
+	helm init --client-only
+	helm package .
+	curl --fail -u $(CHARTMUSEUM_CREDS_USR):$(CHARTMUSEUM_CREDS_PSW) --data-binary "@$(NAME)-$(shell sed -n 's/^version: //p' Chart.yaml).tgz" $(CHART_REPO)/api/charts
+	rm -rf ${NAME}*.tgz%
+
+tag:
+ifeq ($(OS),Darwin)
+	sed -i "" -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
+	sed -i "" -e "s/tag:.*/tag: $(RELEASE_VERSION)/" values.yaml
+else ifeq ($(OS),Linux)
+	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
+	sed -i -e "s|repository:.*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s/tag:.*/tag: $(RELEASE_VERSION)/" values.yaml
+else
+	echo "platfrom $(OS) not supported to release from"
+	exit -1
+endif
+	git add --all
+	git commit -m "chore: release $(RELEASE_VERSION)" --allow-empty # if first release then no verion update is performed
+	git tag -fa v$(RELEASE_VERSION) -m "Release version $(RELEASE_VERSION)"
+	git push origin v$(RELEASE_VERSION)

--- a/packs/javascript-yarn/charts/README.md
+++ b/packs/javascript-yarn/charts/README.md
@@ -1,0 +1,1 @@
+# my application

--- a/packs/javascript-yarn/charts/templates/NOTES.txt
+++ b/packs/javascript-yarn/charts/templates/NOTES.txt
@@ -1,0 +1,4 @@
+
+Get the application URL by running these commands:
+
+kubectl get ingress {{ template "fullname" . }}

--- a/packs/javascript-yarn/charts/templates/_helpers.tpl
+++ b/packs/javascript-yarn/charts/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/packs/javascript-yarn/charts/templates/canary.yaml
+++ b/packs/javascript-yarn/charts/templates/canary.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.canary.enabled }}
+apiVersion: flagger.app/v1beta1
+kind: Canary
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    draft: {{ default "draft-app" .Values.draft }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- if .Values.canary.labels }}
+{{ toYaml .Values.canary.labels | indent 4 }}
+{{- end }}
+spec:
+  provider: istio
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "fullname" . }}
+  progressDeadlineSeconds: {{ .Values.canary.progressDeadlineSeconds }}
+  {{- if .Values.hpa.enabled }}
+  autoscalerRef:
+    apiVersion: autoscaling/v2beta1
+    kind: HorizontalPodAutoscaler
+    name: {{ template "fullname" . }}
+  {{- end }}
+  service:
+    port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+    gateways:
+    - {{ template "fullname" . }}
+    hosts:
+    - {{ .Values.canary.host | default (printf "%s%s%s"  .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain) }}
+  analysis:
+    interval: {{ .Values.canary.analysis.interval }}
+    threshold: {{ .Values.canary.analysis.threshold }}
+    maxWeight: {{ .Values.canary.analysis.maxWeight }}
+    stepWeight: {{ .Values.canary.analysis.stepWeight }}
+    metrics:
+    - name: latency
+      templateRef:
+        name: latency
+        namespace: istio-system
+      thresholdRange:
+        max: {{ .Values.canary.analysis.metrics.latency.threshold }}
+      interval: {{ .Values.canary.analysis.metrics.latency.interval | quote }}
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: {{ template "fullname" . }}
+{{- if .Values.canary.gatewayLabels }}
+  labels:
+{{ toYaml .Values.canary.gatewayLabels | indent 4 }}
+{{- end }}
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: {{ .Values.service.externalPort }}
+      name: http
+      protocol: HTTP
+    hosts:
+    - {{ .Values.canary.host | default (printf "%s%s%s"  .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain) }}
+{{- end }}

--- a/packs/javascript-yarn/charts/templates/deployment.yaml
+++ b/packs/javascript-yarn/charts/templates/deployment.yaml
@@ -1,0 +1,79 @@
+{{- if .Values.knativeDeploy }}
+{{- else }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    draft: {{ default "draft-app" .Values.draft }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- if .Values.deploymentLabels }}
+{{ toYaml .Values.deploymentLabels | indent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+{{- if .Values.hpa.enabled }}
+{{- else }}
+  replicas: {{ .Values.replicaCount }}
+{{- end }}
+  template:
+    metadata:
+      labels:
+        draft: {{ default "draft-app" .Values.draft }}
+        app: {{ template "fullname" . }}
+{{- if .Values.podsLabels }}
+{{ toYaml .Values.podsLabels | indent 6 }}
+{{- end }}
+{{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
+    spec:
+{{- if .Values.serviceAccount.enabled }}
+{{- if .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+{{- else }}
+      serviceAccountName: {{ template "fullname" . }}
+{{- end }}
+{{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: VERSION
+          value: {{ .Chart.Version }}
+{{- range $pkey, $pval := .Values.env }}
+        - name: {{ $pkey }}
+          value: {{ quote $pval }}
+{{- end }}
+        envFrom:
+{{ toYaml .Values.envFrom | indent 10 }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.service.internalPort }}
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.livenessProbe.probePath | default .Values.probePath }}
+            port: {{ .Values.service.internalPort }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.readinessProbe.probePath | default .Values.probePath }}
+            port: {{ .Values.service.internalPort }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+        resources:
+{{ toYaml .Values.resources | indent 12 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      imagePullSecrets:
+{{- range $pval := .Values.jx.imagePullSecrets }}
+      - name: {{ quote $pval }}
+{{- end }}
+{{- end }}

--- a/packs/javascript-yarn/charts/templates/hpa.yaml
+++ b/packs/javascript-yarn/charts/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    draft: {{ default "draft-app" .Values.draft }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- if .Values.hpa.labels }}
+{{ toYaml .Values.hpa.labels | indent 4 }}
+{{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: {{ .Values.hpa.cpuTargetAverageUtilization }}
+  - type: Resource
+    resource:
+      name: memory
+      targetAverageUtilization: {{ .Values.hpa.memoryTargetAverageUtilization }}
+{{- end }}

--- a/packs/javascript-yarn/charts/templates/ingress.yaml
+++ b/packs/javascript-yarn/charts/templates/ingress.yaml
@@ -1,0 +1,48 @@
+{{- if and (.Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}
+{{- if not (hasKey $annotations "kubernetes.io/ingress.class") }}
+{{- $_ := set $annotations "kubernetes.io/ingress.class" (.Values.ingress.classAnnotation | default "nginx") }}
+{{- end }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: {{ .Values.jxRequirements.ingress.apiVersion }}
+kind: Ingress
+metadata:
+  annotations:
+{{- if $annotations }}
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.ingress.labels }}
+{{ toYaml .Values.ingress.labels | indent 4 }}
+{{- end }}
+spec:
+  rules:
+  - http:
+      paths:
+      - pathType: {{ .Values.ingress.pathType | default "ImplementationSpecific" }}
+        backend:
+          service:
+            name: {{ .Values.service.name }}
+            port:
+              number: {{ .Values.service.externalPort }}
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        path: "/{{ .Release.Namespace }}/hook"
+{{- else if .Values.jxRequirements.ingress.domain }}
+    host: {{ .Values.service.name }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+{{- end }}
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  tls:
+  - hosts:
+    - {{ .Values.service.name }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+{{- if and (hasKey .Values.jxRequirements.ingress.tls "secretName") (.Values.jxRequirements.ingress.tls.secretName) }}
+    secretName: "{{ .Values.jxRequirements.ingress.tls.secretName }}"
+{{- else if .Values.jxRequirements.ingress.tls.production }}
+    secretName: "tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-p"
+{{- else }}
+    secretName: "tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-s"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/packs/javascript-yarn/charts/templates/ksvc.yaml
+++ b/packs/javascript-yarn/charts/templates/ksvc.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.knativeDeploy }}
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  {{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+  {{- else }}
+  name: {{ template "fullname" . }}
+  {{- end }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "0"
+{{- if .Values.podsLabels }}
+      labels:
+{{ toYaml .Values.podsLabels | indent 8 }}
+{{- end }}
+    spec:
+      containers:
+        - image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          - name: VERSION
+            value: {{ .Chart.Version }}
+{{- range $pkey, $pval := .Values.env }}
+          - name: {{ $pkey }}
+            value: {{ quote $pval }}
+{{- end }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.probePath | default .Values.probePath }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          readinessProbe:
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.readinessProbe.probePath | default .Values.probePath }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          resources:
+{{ toYaml .Values.resources | indent 14 }}
+{{- end }}

--- a/packs/javascript-yarn/charts/templates/sa.yaml
+++ b/packs/javascript-yarn/charts/templates/sa.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+{{- if .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccount.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
+  {{- if .Values.serviceAccount.labels }}
+  labels: {{- toYaml .Values.serviceAccount.labels | nindent 4 }}
+  {{- end }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/packs/javascript-yarn/charts/templates/service.yaml
+++ b/packs/javascript-yarn/charts/templates/service.yaml
@@ -1,0 +1,29 @@
+{{- if or .Values.knativeDeploy .Values.canary.enabled }}
+{{- else }}
+apiVersion: v1
+kind: Service
+metadata:
+{{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+    protocol: TCP
+    name: http
+  selector:
+    app: {{ template "fullname" . }}
+{{- end }}

--- a/packs/javascript-yarn/charts/values.yaml
+++ b/packs/javascript-yarn/charts/values.yaml
@@ -1,0 +1,135 @@
+# Default values for your projects.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+# Add annotations to the pods
+podAnnotations: {}
+# Add labels to the pods
+podsLabels: {}
+# Add labels to the deployment
+deploymentLabels: {}
+
+image:
+  repository: draft
+  tag: dev
+  pullPolicy: IfNotPresent
+
+# optional list of image pull secrets to use to pull images
+jx:
+  # optional image pull secrets
+  imagePullSecrets: []
+
+  # whether to create a Release CRD when installing charts with Release CRDs included
+  releaseCRD: true
+
+# define environment variables here as a map of key: value
+env:
+
+# enable this flag to use knative serve to deploy the app
+knativeDeploy: false
+
+# HorizontalPodAutoscaler
+hpa:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 6
+  cpuTargetAverageUtilization: 80
+  memoryTargetAverageUtilization: 80
+  # Add labels to the HPA
+  labels: {}
+
+# Canary deployments
+# If enabled, Istio and Flagger need to be installed in the cluster
+canary:
+  enabled: false
+  progressDeadlineSeconds: 60
+  analysis:
+    interval: "1m"
+    threshold: 5
+    maxWeight: 60
+    stepWeight: 20
+    # WARNING: Canary deployments will fail and rollback if there is no traffic that will generate the below specified metrics.
+    metrics:
+      latency:
+        threshold: 500
+        interval: "1m"
+  # The host is using Istio Gateway or the underlying ingress mechanism
+  # This value is defaulted from the environments jx-requirements.yml ingress configuration
+  host: ""
+  # Add labels to the canary
+  labels: {}
+  # Add labels to the canary gateway
+  gatewayLabels: {}
+
+service:
+  name: REPLACE_ME_APP_NAME
+  type: ClusterIP
+  externalPort: 80
+  internalPort: 8080
+  annotations: {}
+  # Add labels to the service
+  labels: {}
+resources:
+  limits:
+    cpu: 400m
+    memory: 256Mi
+  requests:
+    cpu: 0.1
+    memory: 128Mi
+probePath: /
+livenessProbe:
+  initialDelaySeconds: 60
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+  # Optional distinct liveness probe path, if empty the probePath is used
+  probePath: ""
+readinessProbe:
+  failureThreshold: 1
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+  # Optional distinct readiness probe path, if empty the probePath is used
+  probePath: ""
+
+# custom ingress annotations on this service
+ingress:
+  annotations: {}
+  # defaults to nginx if no other ingress class annotation specified
+  classAnnotation: ""
+  # Add labels to the ingress
+  labels: {}
+
+  # ingress path type
+  pathType: ImplementationSpecific
+
+serviceAccount:
+  enabled: true
+  name: ""
+  annotations: {}
+#    iam.gke.io/gcp-service-account: my-sa-in-gke
+  # Add labels to the SA
+  labels: {}
+#    my-custom-label: value
+
+# values we use from the `jx-requirements.yml` file if we are using helmfile and helm 3
+jxRequirements:
+  ingress:
+    # shared ingress annotations on all services
+    annotations: {}
+    #  kubernetes.io/ingress.class: nginx
+
+    apiVersion: "networking.k8s.io/v1"
+
+    # the domain for hosts
+    domain: ""
+    externalDNS: false
+    namespaceSubDomain: -jx.
+    serviceType: ""
+    tls:
+      email: ""
+      enabled: false
+      production: false
+      secretName: ""
+
+

--- a/packs/javascript-yarn/preview/Kptfile
+++ b/packs/javascript-yarn/preview/Kptfile
@@ -1,0 +1,11 @@
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: preview
+upstream:
+  type: git
+  git:
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master

--- a/packs/javascript-yarn/preview/helmfile.yaml
+++ b/packs/javascript-yarn/preview/helmfile.yaml
@@ -1,0 +1,31 @@
+environments:
+  default:
+    values:
+    - jx-values.yaml
+repositories:
+- name: jx3
+  url: https://jenkins-x-charts.github.io/repo
+releases:
+- chart: jx3/jx-verify
+  name: jx-verify
+  namespace: '{{ requiredEnv "PREVIEW_NAMESPACE" }}'
+- chart: '../charts/{{ requiredEnv "APP_NAME" }}'
+  name: preview
+  wait: true
+  createNamespace: true
+  namespace: '{{ requiredEnv "PREVIEW_NAMESPACE" }}'
+  values:
+  - jx-values.yaml
+  - values.yaml.gotmpl
+  hooks:
+  - events: ["presync"]
+    showlogs: true
+    command: "jx"
+    args:
+    - secret
+    - copy
+    - --create-namespace
+    - --selector
+    - "secret.jenkins-x.io/replica-source=true"
+    - --to
+    - '{{ requiredEnv "PREVIEW_NAMESPACE" }}'

--- a/packs/javascript-yarn/preview/values.yaml.gotmpl
+++ b/packs/javascript-yarn/preview/values.yaml.gotmpl
@@ -1,0 +1,8 @@
+jxRequirements:
+  ingress:
+    namespaceSubDomain: "-pr{{ requiredEnv "PULL_NUMBER" }}."
+
+image:
+  repository: "{{ requiredEnv "DOCKER_REGISTRY" }}/{{ requiredEnv "DOCKER_REGISTRY_ORG" }}/{{ requiredEnv "APP_NAME" }}"
+  tag: "{{ requiredEnv "VERSION" }}"
+  pullPolicy: "Always"

--- a/tasks/git-clone/git-clone-pr.yaml
+++ b/tasks/git-clone/git-clone-pr.yaml
@@ -30,7 +30,7 @@ spec:
       git config --global --add user.name ${GIT_AUTHOR_NAME:-jenkins-x-bot}
       git config --global --add user.email ${GIT_AUTHOR_EMAIL:-jenkins-x@googlegroups.com}
       git config --global credential.helper store
-      git clone --depth 1 $REPO_URL $SUBDIR
+      git clone $REPO_URL $SUBDIR
       cd $SUBDIR
       git fetch origin $PULL_PULL_REF:$(echo $JOB_NAME | tr '[:lower:]' '[:upper:]')-$PULL_NUMBER
       git checkout $(echo $JOB_NAME | tr '[:lower:]' '[:upper:]')-$PULL_NUMBER

--- a/tasks/git-clone/git-clone-pr.yaml
+++ b/tasks/git-clone/git-clone-pr.yaml
@@ -30,7 +30,7 @@ spec:
       git config --global --add user.name ${GIT_AUTHOR_NAME:-jenkins-x-bot}
       git config --global --add user.email ${GIT_AUTHOR_EMAIL:-jenkins-x@googlegroups.com}
       git config --global credential.helper store
-      git clone $REPO_URL $SUBDIR
+      git clone --depth 1 $REPO_URL $SUBDIR
       cd $SUBDIR
       git fetch origin $PULL_PULL_REF:$(echo $JOB_NAME | tr '[:lower:]' '[:upper:]')-$PULL_NUMBER
       git checkout $(echo $JOB_NAME | tr '[:lower:]' '[:upper:]')-$PULL_NUMBER

--- a/tasks/git-clone/git-clone.yaml
+++ b/tasks/git-clone/git-clone.yaml
@@ -29,7 +29,7 @@ spec:
       git config --global --add user.name ${GIT_AUTHOR_NAME:-jenkins-x-bot}
       git config --global --add user.email ${GIT_AUTHOR_EMAIL:-jenkins-x@googlegroups.com}
       git config --global credential.helper store
-      git clone --depth 1 $REPO_URL $SUBDIR
+      git clone $REPO_URL $SUBDIR
       cd $SUBDIR
       git reset --hard $PULL_BASE_SHA
       echo "checked out revision: $PULL_BASE_REF@$PULL_BASE_SHA to dir: $SUBDIR"

--- a/tasks/git-clone/git-clone.yaml
+++ b/tasks/git-clone/git-clone.yaml
@@ -29,7 +29,7 @@ spec:
       git config --global --add user.name ${GIT_AUTHOR_NAME:-jenkins-x-bot}
       git config --global --add user.email ${GIT_AUTHOR_EMAIL:-jenkins-x@googlegroups.com}
       git config --global credential.helper store
-      git clone $REPO_URL $SUBDIR
+      git clone --depth=1 $REPO_URL $SUBDIR
       cd $SUBDIR
       git reset --hard $PULL_BASE_SHA
       echo "checked out revision: $PULL_BASE_REF@$PULL_BASE_SHA to dir: $SUBDIR"

--- a/tasks/git-clone/git-clone.yaml
+++ b/tasks/git-clone/git-clone.yaml
@@ -29,7 +29,7 @@ spec:
       git config --global --add user.name ${GIT_AUTHOR_NAME:-jenkins-x-bot}
       git config --global --add user.email ${GIT_AUTHOR_EMAIL:-jenkins-x@googlegroups.com}
       git config --global credential.helper store
-      git clone --depth=1 $REPO_URL $SUBDIR
+      git clone --depth 1 $REPO_URL $SUBDIR
       cd $SUBDIR
       git reset --hard $PULL_BASE_SHA
       echo "checked out revision: $PULL_BASE_REF@$PULL_BASE_SHA to dir: $SUBDIR"

--- a/tasks/javascript-yarn/pullrequest.yaml
+++ b/tasks/javascript-yarn/pullrequest.yaml
@@ -1,0 +1,80 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  name: pullrequest
+spec:
+  pipelineSpec:
+    tasks:
+    - name: from-build-pack
+      resources: {}
+      taskSpec:
+        metadata: {}
+        stepTemplate:
+          env:
+          - name: NPM_CONFIG_USERCONFIG
+            value: /tekton/home/npm/.npmrc
+          - name: HOME
+            value: /tekton/home
+          envFrom:
+          - secretRef:
+              name: jx-boot-job-env-vars
+              optional: true
+          name: ""
+          resources:
+            limits: {}
+          volumeMounts:
+          - mountPath: /tekton/home/npm
+            name: npmrc
+          workingDir: /workspace/source
+        steps:
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.83
+          name: jx-variables
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
+          script: |
+            #!/usr/bin/env sh
+            jx gitops variables
+            jx gitops pr variables
+        - image: node:14-slim
+          name: build-npm-install
+          resources: {}
+          script: |
+            #!/bin/sh
+            npm install
+        - image: node:14-slim
+          name: build-npm-test
+          resources: {}
+          script: |
+            #!/bin/sh
+            CI=true DISPLAY=:99 npm test
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.10
+          name: check-registry
+          resources: {}
+        - image: gcr.io/kaniko-project/executor:v1.9.1-debug
+          name: build-container-build
+          resources: {}
+          script: |
+            #!/busybox/sh
+            source .jx/variables.sh
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
+            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
+        - image: ghcr.io/jenkins-x-plugins/jx-preview:0.0.240
+          name: promote-jx-preview
+          resources: {}
+          script: |
+            #!/usr/bin/env sh
+            source .jx/variables.sh
+            jx preview create
+        volumes:
+        - name: npmrc
+          secret:
+            optional: true
+            secretName: npmrc
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 12h0m0s
+status: {}

--- a/tasks/javascript-yarn/pullrequest.yaml
+++ b/tasks/javascript-yarn/pullrequest.yaml
@@ -40,17 +40,17 @@ spec:
             jx gitops variables
             jx gitops pr variables
         - image: node:14-slim
-          name: build-npm-install
+          name: build-yarn-install
           resources: {}
           script: |
             #!/bin/sh
-            npm install
+            yarn install
         - image: node:14-slim
-          name: build-npm-test
+          name: build-yarn-test
           resources: {}
           script: |
             #!/bin/sh
-            CI=true DISPLAY=:99 npm test
+            CI=true DISPLAY=:99 yarn test
         - image: ghcr.io/jenkins-x/jx-registry:0.1.10
           name: check-registry
           resources: {}

--- a/tasks/javascript-yarn/release.yaml
+++ b/tasks/javascript-yarn/release.yaml
@@ -56,17 +56,17 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
         - image: node:14-slim
-          name: build-npm-install
+          name: build-yarn-install
           resources: {}
           script: |
             #!/bin/sh
-            npm install
+            yarn install
         - image: node:14-slim
-          name: build-npm-test
+          name: build-yarn-test
           resources: {}
           script: |
             #!/bin/sh
-            CI=true DISPLAY=:99 npm test
+            CI=true DISPLAY=:99 yarn test
         - image: ghcr.io/jenkins-x/jx-registry:0.1.10
           name: check-registry
           resources: {}

--- a/tasks/javascript-yarn/release.yaml
+++ b/tasks/javascript-yarn/release.yaml
@@ -1,0 +1,124 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  name: release
+spec:
+  pipelineSpec:
+    tasks:
+    - name: from-build-pack
+      resources: {}
+      taskSpec:
+        metadata: {}
+        stepTemplate:
+          env:
+          - name: NPM_CONFIG_USERCONFIG
+            value: /tekton/home/npm/.npmrc
+          - name: HOME
+            value: /tekton/home
+          envFrom:
+          - secretRef:
+              name: jx-boot-job-env-vars
+              optional: true
+          name: ""
+          resources:
+            limits: {}
+          volumeMounts:
+          - mountPath: /tekton/home/npm
+            name: npmrc
+          workingDir: /workspace/source
+        steps:
+        - env:
+          - name: GIT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                key: password
+                name: tekton-git
+          - name: GIT_USER
+            valueFrom:
+              secretKeyRef:
+                key: username
+                name: tekton-git
+          image: ghcr.io/jenkins-x/jx-release-version:2.6.10
+          name: next-version
+          resources: {}
+          script: |
+            #!/usr/bin/env sh
+            jx-release-version --tag > VERSION
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.83
+          name: jx-variables
+          resources:
+            # set requests for the pod here
+            requests:
+              cpu: 400m
+              memory: 512Mi
+          script: |
+            #!/usr/bin/env sh
+            jx gitops variables
+        - image: node:14-slim
+          name: build-npm-install
+          resources: {}
+          script: |
+            #!/bin/sh
+            npm install
+        - image: node:14-slim
+          name: build-npm-test
+          resources: {}
+          script: |
+            #!/bin/sh
+            CI=true DISPLAY=:99 npm test
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.10
+          name: check-registry
+          resources: {}
+        - image: gcr.io/kaniko-project/executor:v1.9.1-debug
+          name: build-container-build
+          resources: {}
+          script: |
+            #!/busybox/sh
+            source .jx/variables.sh
+            cp /tekton/creds/.docker/config.json /kaniko/.docker/config.json
+            /kaniko/executor $KANIKO_FLAGS --context=/workspace/source --dockerfile=${DOCKERFILE_PATH:-Dockerfile} --destination=$PUSH_CONTAINER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$VERSION
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.83
+          name: promote-changelog
+          resources: {}
+          script: |
+            #!/usr/bin/env sh
+            source .jx/variables.sh
+
+            if [ -d "charts/$REPO_NAME" ]; then
+            jx gitops yset -p version -v "$VERSION" -f ./charts/$REPO_NAME/Chart.yaml
+            jx gitops yset -p appVersion -v "$VERSION" -f ./charts/$REPO_NAME/Chart.yaml
+            yq e -i '.sources = ((.sources // []) + "'$REPO_URL'" | unique)' ./charts/$REPO_NAME/Chart.yaml
+            jx gitops yset -p 'image.repository' -v $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME -f ./charts/$REPO_NAME/values.yaml
+            jx gitops yset -p 'image.tag' -v "$VERSION" -f ./charts/$REPO_NAME/values.yaml;
+            else echo no charts; fi
+
+            git add * || true
+            git commit -a -m "chore: release $VERSION" --allow-empty
+            git tag -fa v$VERSION -m "Release version $VERSION"
+            git push --force origin v$VERSION
+
+            jx changelog create --version v${VERSION} --output-markdown ../changelog.md
+        - image: ghcr.io/jenkins-x/jx-boot:3.10.83
+          name: promote-helm-release
+          resources: {}
+          script: |
+            #!/usr/bin/env sh
+            source .jx/variables.sh
+            jx gitops helm release
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.6.4
+          name: promote-jx-promote
+          resources: {}
+          script: |
+            #!/usr/bin/env sh
+            source .jx/variables.sh
+            jx promote -b --all --timeout 1h --no-poll --add-changelog ../changelog.md
+        volumes:
+        - name: npmrc
+          secret:
+            optional: true
+            secretName: npmrc
+  podTemplate: {}
+  serviceAccountName: tekton-bot
+  timeout: 12h0m0s
+status: {}


### PR DESCRIPTION
I have created a javascript-yarn pack and tasks based on the standard javascript task/pack so i can use the yarn command to build a react project, instead of npm.

In order to keep the proposed change as close to the current standard JS pack/task, i only update the command on the tasks (PR and Release), and the reference to the task on the pack PR and release files.
io did not update any version for NodeJS or the icon on the Chart template (again, to be as close to the current javascript pack/task.
I'm currently using the task from a forked repo, so they work on my deployment