### PR TITLE
fix: source not found in sh

### DIFF
--- a/tasks/go-plugin-multiarch/release.yaml
+++ b/tasks/go-plugin-multiarch/release.yaml
@@ -50,7 +50,7 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            source .jx/variables.sh
+            . .jx/variables.sh
             make release
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug
           name: build-and-push-image

--- a/tasks/go-plugin/release.yaml
+++ b/tasks/go-plugin/release.yaml
@@ -50,7 +50,7 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            source .jx/variables.sh
+            . .jx/variables.sh
             make release
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug
           name: build-and-push-image


### PR DESCRIPTION
In plugin pipelines we see error messages like:

 /tekton/scripts/script-3-qzmt6: 2: source: not found 

This is due to the fact that source doesn't (necessarily) exist in sh

The only real effect I have seen though is that version, branch and such details isn't set correctly in plugins. Though this is often also due to the wrong file being specified to put the version...