### PR TITLE
fix: don't do unnecessary deploy

### DIFF
--- a/packs/appserver/.lighthouse/jenkins-x/release.yaml
+++ b/packs/appserver/.lighthouse/jenkins-x/release.yaml
@@ -37,7 +37,7 @@ spec:
             requests:
               cpu: 400m
               memory: 512Mi
-        - name: build-mvn-deploy
+        - name: build-mvn-install
           resources: {}
         - name: check-registry
           resources: {}

--- a/packs/maven-java11/.lighthouse/jenkins-x/release.yaml
+++ b/packs/maven-java11/.lighthouse/jenkins-x/release.yaml
@@ -41,7 +41,7 @@ spec:
             requests:
               cpu: 400m
               memory: 512Mi
-        - name: build-mvn-deploy
+        - name: build-mvn-install
           resources: {}
         - name: check-registry
           resources: {}

--- a/packs/maven-java14/.lighthouse/jenkins-x/release.yaml
+++ b/packs/maven-java14/.lighthouse/jenkins-x/release.yaml
@@ -41,7 +41,7 @@ spec:
             requests:
               cpu: 400m
               memory: 512Mi
-        - name: build-mvn-deploy
+        - name: build-mvn-install
           resources: {}
         - name: check-registry
           resources: {}

--- a/packs/maven-java16/.lighthouse/jenkins-x/release.yaml
+++ b/packs/maven-java16/.lighthouse/jenkins-x/release.yaml
@@ -37,7 +37,7 @@ spec:
             requests:
               cpu: 400m
               memory: 512Mi
-        - name: build-mvn-deploy
+        - name: build-mvn-install
           resources: {}
         - name: check-registry
           resources: {}

--- a/packs/maven-java17/.lighthouse/jenkins-x/release.yaml
+++ b/packs/maven-java17/.lighthouse/jenkins-x/release.yaml
@@ -37,7 +37,7 @@ spec:
             requests:
               cpu: 400m
               memory: 512Mi
-        - name: build-mvn-deploy
+        - name: build-mvn-install
           resources: {}
         - name: check-registry
           resources: {}

--- a/packs/maven-node-ruby/.lighthouse/jenkins-x/release.yaml
+++ b/packs/maven-node-ruby/.lighthouse/jenkins-x/release.yaml
@@ -42,7 +42,7 @@ spec:
             requests:
               cpu: 400m
               memory: 512Mi
-        - name: build-mvn-deploy
+        - name: build-mvn-install
           resources: {}
         - name: check-registry
           resources: {}

--- a/packs/maven-quarkus-native/.lighthouse/jenkins-x/release.yaml
+++ b/packs/maven-quarkus-native/.lighthouse/jenkins-x/release.yaml
@@ -42,7 +42,7 @@ spec:
             requests:
               cpu: 400m
               memory: 2Gi
-        - name: build-mvn-deploy
+        - name: build-mvn-install
           resources: {}
         - name: check-registry
           resources: {}

--- a/packs/maven-quarkus/.lighthouse/jenkins-x/release.yaml
+++ b/packs/maven-quarkus/.lighthouse/jenkins-x/release.yaml
@@ -41,7 +41,7 @@ spec:
             requests:
               cpu: 400m
               memory: 2Gi
-        - name: build-mvn-deploy
+        - name: build-mvn-install
           resources: {}
         - name: check-registry
           resources: {}

--- a/packs/maven/.lighthouse/jenkins-x/release.yaml
+++ b/packs/maven/.lighthouse/jenkins-x/release.yaml
@@ -42,7 +42,7 @@ spec:
             requests:
               cpu: 400m
               memory: 512Mi
-        - name: build-mvn-deploy
+        - name: build-mvn-install
           resources: {}
         - name: check-registry
           resources: {}

--- a/tasks/appserver/release.yaml
+++ b/tasks/appserver/release.yaml
@@ -59,11 +59,17 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
         - image: maven:3.6-openjdk-8
+          name: build-mvn-install
+          resources: {}
+          script: |
+            #!/bin/sh
+            mvn --no-transfer-progress install
+        - image: maven:3.6-openjdk-8
           name: build-mvn-deploy
           resources: {}
           script: |
             #!/bin/sh
-            mvn --no-transfer-progress clean deploy
+            mvn --no-transfer-progress deploy
         - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}

--- a/tasks/maven-java11/release.yaml
+++ b/tasks/maven-java11/release.yaml
@@ -63,6 +63,18 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
         - image: maven:3.6-openjdk-11
+          name: build-mvn-install
+          resources: {}
+          script: |
+            #!/usr/bin/env bash
+            source .jx/variables.sh
+
+            # modify the pom.xml
+            echo "upgrading the pom to version $VERSION"
+            mvn versions:set -DnewVersion=$VERSION
+
+            mvn --no-transfer-progress install
+        - image: maven:3.6-openjdk-11
           name: build-mvn-deploy
           resources: {}
           script: |
@@ -73,7 +85,7 @@ spec:
             echo "upgrading the pom to version $VERSION"
             mvn versions:set -DnewVersion=$VERSION
 
-            mvn --no-transfer-progress clean deploy
+            mvn --no-transfer-progress deploy
         - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}

--- a/tasks/maven-java14/release.yaml
+++ b/tasks/maven-java14/release.yaml
@@ -59,6 +59,18 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
         - image: maven:3.8-openjdk-15
+          name: build-mvn-install
+          resources: {}
+          script: |
+            #!/usr/bin/env bash
+            source .jx/variables.sh
+
+            # modify the pom.xml
+            echo "upgrading the pom to version $VERSION"
+            mvn versions:set -DnewVersion=$VERSION
+
+            mvn --no-transfer-progress install
+        - image: maven:3.8-openjdk-15
           name: build-mvn-deploy
           resources: {}
           script: |
@@ -69,7 +81,7 @@ spec:
             echo "upgrading the pom to version $VERSION"
             mvn versions:set -DnewVersion=$VERSION
 
-            mvn --no-transfer-progress clean deploy
+            mvn --no-transfer-progress deploy
         - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}

--- a/tasks/maven-java16/release.yaml
+++ b/tasks/maven-java16/release.yaml
@@ -59,6 +59,18 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
         - image: maven:3.8-openjdk-16
+          name: build-mvn-install
+          resources: {}
+          script: |
+            #!/usr/bin/env bash
+            source .jx/variables.sh
+
+            # modify the pom.xml
+            echo "upgrading the pom to version $VERSION"
+            mvn versions:set -DnewVersion=$VERSION
+
+            mvn --no-transfer-progress install
+        - image: maven:3.8-openjdk-16
           name: build-mvn-deploy
           resources: {}
           script: |
@@ -69,7 +81,7 @@ spec:
             echo "upgrading the pom to version $VERSION"
             mvn versions:set -DnewVersion=$VERSION
 
-            mvn --no-transfer-progress clean deploy
+            mvn --no-transfer-progress deploy
         - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}

--- a/tasks/maven-java17/release.yaml
+++ b/tasks/maven-java17/release.yaml
@@ -59,6 +59,18 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
         - image: maven:3.8.2-openjdk-17
+          name: build-mvn-install
+          resources: {}
+          script: |
+            #!/usr/bin/env bash
+            source .jx/variables.sh
+
+            # modify the pom.xml
+            echo "upgrading the pom to version $VERSION"
+            mvn versions:set -DnewVersion=$VERSION
+
+            mvn --no-transfer-progress install
+        - image: maven:3.8.2-openjdk-17
           name: build-mvn-deploy
           resources: {}
           script: |
@@ -69,7 +81,7 @@ spec:
             echo "upgrading the pom to version $VERSION"
             mvn versions:set -DnewVersion=$VERSION
 
-            mvn --no-transfer-progress clean deploy
+            mvn --no-transfer-progress deploy
         - image: maven:3.8.2-openjdk-17
           name: build-mvn-install
           resources: {}

--- a/tasks/maven-node-ruby/release.yaml
+++ b/tasks/maven-node-ruby/release.yaml
@@ -64,6 +64,18 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
         - image: maven:3.6-openjdk-8
+          name: build-mvn-install
+          resources: {}
+          script: |
+            #!/usr/bin/env bash
+            source .jx/variables.sh
+
+            # modify the pom.xml
+            echo "upgrading the pom to version $VERSION"
+            mvn versions:set -DnewVersion=$VERSION
+
+            mvn --no-transfer-progress install
+        - image: maven:3.6-openjdk-8
           name: build-mvn-deploy
           resources: {}
           script: |
@@ -74,7 +86,7 @@ spec:
             echo "upgrading the pom to version $VERSION"
             mvn versions:set -DnewVersion=$VERSION
 
-            mvn --no-transfer-progress clean deploy
+            mvn --no-transfer-progress deploy
         - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}

--- a/tasks/maven-quarkus-native/release.yaml
+++ b/tasks/maven-quarkus-native/release.yaml
@@ -62,6 +62,18 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
         - image: ghcr.io/jenkins-x/maven-quarkus-mandrel:0.0.2
+          name: build-mvn-install
+          resources:
+          script: |
+            #!/usr/bin/env bash
+            source .jx/variables.sh
+
+            # modify the pom.xml
+            echo "upgrading the pom to version $VERSION"
+            mvn versions:set -DnewVersion=$VERSION
+
+            mvn --no-transfer-progress install -Pnative
+        - image: ghcr.io/jenkins-x/maven-quarkus-mandrel:0.0.2
           name: build-mvn-deploy
           resources:
           script: |
@@ -72,7 +84,7 @@ spec:
             echo "upgrading the pom to version $VERSION"
             mvn versions:set -DnewVersion=$VERSION
 
-            mvn --no-transfer-progress clean deploy -Pnative
+            mvn --no-transfer-progress deploy -Pnative
         - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}

--- a/tasks/maven-quarkus/release.yaml
+++ b/tasks/maven-quarkus/release.yaml
@@ -63,6 +63,18 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
         - image: ghcr.io/jenkins-x/builder-maven-graalvm:2.1.155-779
+          name: build-mvn-install
+          resources: {}
+          script: |
+            #!/usr/bin/env bash
+            source .jx/variables.sh
+
+            # modify the pom.xml
+            echo "upgrading the pom to version $VERSION"
+            mvn versions:set -DnewVersion=$VERSION
+
+            mvn --no-transfer-progress install
+        - image: ghcr.io/jenkins-x/builder-maven-graalvm:2.1.155-779
           name: build-mvn-deploy
           resources: {}
           script: |
@@ -73,7 +85,7 @@ spec:
             echo "upgrading the pom to version $VERSION"
             mvn versions:set -DnewVersion=$VERSION
 
-            mvn --no-transfer-progress clean deploy
+            mvn --no-transfer-progress deploy
         - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}

--- a/tasks/maven/release.yaml
+++ b/tasks/maven/release.yaml
@@ -64,6 +64,18 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
         - image: maven:3.6-openjdk-8-slim
+          name: build-mvn-install
+          resources: {}
+          script: |
+            #!/usr/bin/env bash
+            source .jx/variables.sh
+
+            # modify the pom.xml
+            echo "upgrading the pom to version $VERSION"
+            mvn versions:set -DnewVersion=$VERSION
+
+            mvn --no-transfer-progress install
+        - image: maven:3.6-openjdk-8-slim
           name: build-mvn-deploy
           resources: {}
           script: |
@@ -74,7 +86,7 @@ spec:
             echo "upgrading the pom to version $VERSION"
             mvn versions:set -DnewVersion=$VERSION
 
-            mvn --no-transfer-progress clean deploy
+            mvn --no-transfer-progress deploy
         - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}


### PR DESCRIPTION
Applications typically don't need to be deployed (i.e. have their artifact uploaded to a nexus or such). So I add new step build-mvn-install for most maven based tasks and replace build-mvn-deploy with it in the packs.

Also removing clean, since it's not needed when building in a fresh clone.

The build-mvn-deploy steps are left both so existing pipelines doesn't break and to support pipelines for libraries