### PR TITLE
fix: source variables in make-build to get version

### DIFF
--- a/tasks/go-cli/pullrequest.yaml
+++ b/tasks/go-cli/pullrequest.yaml
@@ -38,7 +38,8 @@ spec:
           name: build-make-linux
           resources: {}
           script: |
-            #!/bin/sh
+            #!/bin/bash
+            source .jx/variables.sh
             make linux
         - image: golang:1.19.3@sha256:7ffa70183b7596e6bc1b78c132dbba9a6e05a26cd30eaa9832fecad64b83f029
           name: build-make-test

--- a/tasks/go-mongodb/pullrequest.yaml
+++ b/tasks/go-mongodb/pullrequest.yaml
@@ -38,7 +38,8 @@ spec:
           name: build-make-linux
           resources: {}
           script: |
-            #!/bin/sh
+            #!/bin/bash
+            source .jx/variables.sh
             make linux
         - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry

--- a/tasks/go-mongodb/release.yaml
+++ b/tasks/go-mongodb/release.yaml
@@ -54,7 +54,8 @@ spec:
           name: build-make-build
           resources: {}
           script: |
-            #!/bin/sh
+            #!/bin/bash
+            source .jx/variables.sh
             make build
         - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry

--- a/tasks/go-plugin-multiarch/pullrequest.yaml
+++ b/tasks/go-plugin-multiarch/pullrequest.yaml
@@ -38,7 +38,8 @@ spec:
           name: build-make-linux
           resources: {}
           script: |
-            #!/bin/sh
+            #!/bin/bash
+            source .jx/variables.sh
             make linux
         - image: golangci/golangci-lint:v1.50.1-alpine@sha256:a392d4e44049a444a927878792dae9534075ec57880e0657647ce818bd8278c2
           name: make-lint

--- a/tasks/go-plugin-multiarch/release.yaml
+++ b/tasks/go-plugin-multiarch/release.yaml
@@ -49,8 +49,8 @@ spec:
           name: release-binary
           resources: {}
           script: |
-            #!/usr/bin/env sh
-            . .jx/variables.sh
+            #!/bin/bash
+            source .jx/variables.sh
             make release
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug
           name: build-and-push-image

--- a/tasks/go-plugin/pullrequest.yaml
+++ b/tasks/go-plugin/pullrequest.yaml
@@ -50,7 +50,8 @@ spec:
           name: build-make-test
           resources: {}
           script: |
-            #!/bin/sh
+            #!/bin/bash
+            source .jx/variables.sh
             make test
         - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry

--- a/tasks/go-plugin/release.yaml
+++ b/tasks/go-plugin/release.yaml
@@ -49,8 +49,8 @@ spec:
           name: release-binary
           resources: {}
           script: |
-            #!/usr/bin/env sh
-            . .jx/variables.sh
+            #!/bin/bash
+            source .jx/variables.sh
             make release
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug
           name: build-and-push-image

--- a/tasks/go/pullrequest.yaml
+++ b/tasks/go/pullrequest.yaml
@@ -38,7 +38,8 @@ spec:
           name: build-make-linux
           resources: {}
           script: |
-            #!/bin/sh
+            #!/bin/bash
+            source .jx/variables.sh
             make linux
         - image: golangci/golangci-lint:v1.50.1-alpine@sha256:a392d4e44049a444a927878792dae9534075ec57880e0657647ce818bd8278c2
           name: make-lint

--- a/tasks/go/release.yaml
+++ b/tasks/go/release.yaml
@@ -54,7 +54,8 @@ spec:
           name: build-make-build
           resources: {}
           script: |
-            #!/bin/sh
+            #!/bin/bash
+            source .jx/variables.sh
             make build
         - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry


### PR DESCRIPTION
Go `build-make-build` doesn't set the correct version as $VERSION isn't set so it's just pulling from the git tags (ends up with "1.0.0-dev...").

Sourcing version from variables gives the build the correct version for the release.