### PR TITLE
fix: add missing labels field

### DIFF
--- a/helm/charts/templates/ingress.yaml
+++ b/helm/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/C++/charts/templates/ingress.yaml
+++ b/packs/C++/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/D/charts/templates/ingress.yaml
+++ b/packs/D/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/appserver/charts/templates/ingress.yaml
+++ b/packs/appserver/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/csharp/charts/templates/ingress.yaml
+++ b/packs/csharp/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/cwp/charts/templates/ingress.yaml
+++ b/packs/cwp/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/go-mongodb/charts/templates/ingress.yaml
+++ b/packs/go-mongodb/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/go/charts/templates/ingress.yaml
+++ b/packs/go/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/gradle/charts/templates/ingress.yaml
+++ b/packs/gradle/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/javascript-ui-nginx/charts/templates/ingress.yaml
+++ b/packs/javascript-ui-nginx/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/javascript/charts/templates/ingress.yaml
+++ b/packs/javascript/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/maven-java11/charts/templates/ingress.yaml
+++ b/packs/maven-java11/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/maven-java14/charts/templates/ingress.yaml
+++ b/packs/maven-java14/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/maven-java16/charts/templates/ingress.yaml
+++ b/packs/maven-java16/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/maven-java17/charts/templates/ingress.yaml
+++ b/packs/maven-java17/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/maven-node-ruby/charts/templates/ingress.yaml
+++ b/packs/maven-node-ruby/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/maven-quarkus-native/charts/templates/ingress.yaml
+++ b/packs/maven-quarkus-native/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/maven-quarkus/charts/templates/ingress.yaml
+++ b/packs/maven-quarkus/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/maven/charts/templates/ingress.yaml
+++ b/packs/maven/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/ml-python-gpu-service/charts/templates/ingress.yaml
+++ b/packs/ml-python-gpu-service/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/ml-python-gpu-training/charts/templates/ingress.yaml
+++ b/packs/ml-python-gpu-training/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/ml-python-service/charts/templates/ingress.yaml
+++ b/packs/ml-python-service/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/ml-python-training/charts/templates/ingress.yaml
+++ b/packs/ml-python-training/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/php/charts/templates/ingress.yaml
+++ b/packs/php/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/python/charts/templates/ingress.yaml
+++ b/packs/python/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/ruby/charts/templates/ingress.yaml
+++ b/packs/ruby/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/rust/charts/templates/ingress.yaml
+++ b/packs/rust/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/scala/charts/templates/ingress.yaml
+++ b/packs/scala/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:

--- a/packs/typescript/charts/templates/ingress.yaml
+++ b/packs/typescript/charts/templates/ingress.yaml
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
   name: {{ .Values.service.name }}
 {{- if .Values.ingress.labels }}
+  labels:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:


### PR DESCRIPTION
It's a bit surprising that setting labels on ingresses via the helm charts of applications created from the packs has been broken until now. But so it is...