### PR TITLE
Reset and retry rebase upon PR regeneration conflicts

### DIFF
--- a/tasks/git-clone/git-clone-env-pr.yaml
+++ b/tasks/git-clone/git-clone-env-pr.yaml
@@ -45,17 +45,23 @@ spec:
     resources: {}
     script: |
       #!/usr/bin/env sh
-
-      # To ensure idempotency, reset the branch to its initial state since a previous
-      # rebase can change the branch's initial state before the regeneration commit.
-      if git log -1 --pretty=%B | grep -i regenerate; then
-        git reset --hard HEAD~1
-      fi
-
-      # '-r' to avoid unexpected conflicts (e.g. rename/rename) when trying to rebase commits sharing the same base commit.
-      # Preserving the merge commits thus ensures commits are always applied on top of their original base branch before being
-      # merged back into the rebased branch.
-      jx gitops git merge --rebase --merge-arg "-Xtheirs -r"
+      counter=0
+      # Since a previous rebase can change the initial state of the branch, a successive rebase attempt can result in a conflict due to
+      # the previous regeneration commit attempting to be picked ontop of a different initial state of the PR's branch. Thus, this retry
+      # logic attempts to remove the latest regeneration commit and attempt the rebase again upon such conflicts.
+      until [ "$counter" -eq 3 ]; do
+        # lets avoid git rebase/merge conflicts on promotions
+        # '-r' to avoid unexpected conflicts (e.g. rename/rename) when trying to rebase commits sharing the same base commit.
+        # Preserving the merge commits thus ensures commits are always applied on top of their original base branch before being
+        # merged back into the rebased branch.
+        jx gitops git merge --rebase --merge-arg "-Xtheirs -r" && exit 0
+        counter=$((counter+1))
+        git rebase --abort
+        if git log -1 --pretty=%B | grep -i regenerate; then
+          git reset --hard HEAD~1
+        fi
+      done
+      exit 1
     workingDir: /workspace/source
   workspaces:
   - description: The git repo will be cloned onto the volume backing this workspace

--- a/tasks/git-clone/git-clone-env-pr.yaml
+++ b/tasks/git-clone/git-clone-env-pr.yaml
@@ -46,6 +46,12 @@ spec:
     script: |
       #!/usr/bin/env sh
 
+      # To ensure idempotency, reset the branch to its initial state since a previous
+      # rebase can change the branch's initial state before the regeneration commit.
+      if git log -1 --pretty=%B | grep -i regenerate; then
+        git reset --hard HEAD~1
+      fi
+
       # '-r' to avoid unexpected conflicts (e.g. rename/rename) when trying to rebase commits sharing the same base commit.
       # Preserving the merge commits thus ensures commits are always applied on top of their original base branch before being
       # merged back into the rebased branch.


### PR DESCRIPTION
This PR adds back the mistakenly removed [retry logic](https://github.com/brandong954/jx3-pipeline-catalog/commit/eb1c3fbf622729d0f7a23ebceeff0a7d203a7f63) within #1470 since e previous rebase attempt can change the initial state of the PR's branch, and thus cause the `regeneration` commit to see conflicts when picked in a successive rebase attempt. Note, this fix is exclusive to itself and not related to the recent [fix](https://github.com/jenkins-x/jx3-pipeline-catalog/pull/1470) for ensuring all `regeneration` commits **outside** of the PR's branch are rebased without conflict.

In other words, the `-r` flag fixed rebase conflicts for `regeneration` commits **outside** of the PR’s branch, but not within it, so both pieces are needed to hopefully resolve all the rebase issues.




