### PR TITLE
Add label version in deployment specification for compatibility with istio 

### DIFF
--- a/packs/go-mongodb/charts/templates/deployment.yaml
+++ b/packs/go-mongodb/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}

--- a/packs/go/charts/templates/deployment.yaml
+++ b/packs/go/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}

--- a/packs/gradle/charts/templates/deployment.yaml
+++ b/packs/gradle/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}

--- a/packs/javascript-ui-nginx/charts/templates/deployment.yaml
+++ b/packs/javascript-ui-nginx/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}

--- a/packs/javascript-yarn/charts/templates/deployment.yaml
+++ b/packs/javascript-yarn/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}

--- a/packs/javascript/charts/templates/deployment.yaml
+++ b/packs/javascript/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}

--- a/packs/maven-java11/charts/templates/deployment.yaml
+++ b/packs/maven-java11/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}

--- a/packs/maven-java14/charts/templates/deployment.yaml
+++ b/packs/maven-java14/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}

--- a/packs/maven-java16/charts/templates/deployment.yaml
+++ b/packs/maven-java16/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}

--- a/packs/maven-java17/charts/templates/deployment.yaml
+++ b/packs/maven-java17/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}

--- a/packs/maven-java21/charts/templates/deployment.yaml
+++ b/packs/maven-java21/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}

--- a/packs/maven-node-ruby/charts/templates/deployment.yaml
+++ b/packs/maven-node-ruby/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}

--- a/packs/maven-quarkus-native/charts/templates/deployment.yaml
+++ b/packs/maven-quarkus-native/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}

--- a/packs/maven-quarkus/charts/templates/deployment.yaml
+++ b/packs/maven-quarkus/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}

--- a/packs/maven/charts/templates/deployment.yaml
+++ b/packs/maven/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}

--- a/packs/ml-python-gpu-service/charts/templates/deployment.yaml
+++ b/packs/ml-python-gpu-service/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}

--- a/packs/ml-python-gpu-training/charts/templates/deployment.yaml
+++ b/packs/ml-python-gpu-training/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}

--- a/packs/ml-python-service/charts/templates/deployment.yaml
+++ b/packs/ml-python-service/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}

--- a/packs/ml-python-training/charts/templates/deployment.yaml
+++ b/packs/ml-python-training/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}

--- a/packs/php/charts/templates/deployment.yaml
+++ b/packs/php/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}

--- a/packs/python/charts/templates/deployment.yaml
+++ b/packs/python/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}

--- a/packs/ruby/charts/templates/deployment.yaml
+++ b/packs/ruby/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}

--- a/packs/rust/charts/templates/deployment.yaml
+++ b/packs/rust/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}

--- a/packs/scala/charts/templates/deployment.yaml
+++ b/packs/scala/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}

--- a/packs/typescript/charts/templates/deployment.yaml
+++ b/packs/typescript/charts/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        service.istio.io/canonical-name: "{{ .Values.service.istioCanonicalName | default (template "fullname" .) }}"
+        service.istio.io/canonical-revision: "{{ .Values.service.istioCanonicalRevision | default .Chart.Version }}"
+        app.kubernetes.io/name: "{{ .Values.app.kubernetesName | default (template "fullname" .) }}"
+        app.kubernetes.io/version: "{{ .Values.app.kubernetesVersion | default .Chart.Version }}"
 {{- if .Values.podsLabels }}
 {{ toYaml .Values.podsLabels | indent 6 }}
 {{- end }}


### PR DESCRIPTION
# What will this PR will do ?

This PR updates the **Helm Deployment template to include Istio-recommended labels in the pod metadata**. These labels enhance the telemetry and observability capabilities provided by Istio, ensuring better integration and contextual metrics collection.

# Changes Made
- Added Istio-Specific Labels:
```service.istio.io/canonical-name```: Identifies the canonical name of the application.
```service.istio.io/canonical-revision```: Specifies the version or revision of the application.
- Added Kubernetes Standard Labels:
```app.kubernetes.io/name```: Indicates the name of the application.
```app.kubernetes.io/version```: Defines the version of the application.

Fixes jenkins-x/jx#2705