### PR TITLE
Revert "chore(deps): upgrade to version 0.1.12"

### DIFF
--- a/tasks/C++/pullrequest.yaml
+++ b/tasks/C++/pullrequest.yaml
@@ -41,7 +41,7 @@ spec:
           script: |
             #!/bin/sh
             make
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/C++/release.yaml
+++ b/tasks/C++/release.yaml
@@ -57,7 +57,7 @@ spec:
           script: |
             #!/bin/sh
             make
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/D/pullrequest.yaml
+++ b/tasks/D/pullrequest.yaml
@@ -40,7 +40,7 @@ spec:
           script: |
             #!/bin/sh
             dub build --build=release
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/D/release.yaml
+++ b/tasks/D/release.yaml
@@ -56,7 +56,7 @@ spec:
           script: |
             #!/bin/sh
             dub build --build=release
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/appserver/pullrequest.yaml
+++ b/tasks/appserver/pullrequest.yaml
@@ -55,7 +55,7 @@ spec:
           script: |
             #!/bin/sh
             mvn --no-transfer-progress install
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/appserver/release.yaml
+++ b/tasks/appserver/release.yaml
@@ -70,7 +70,7 @@ spec:
           script: |
             #!/bin/sh
             mvn --no-transfer-progress deploy
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/csharp/pullrequest.yaml
+++ b/tasks/csharp/pullrequest.yaml
@@ -34,7 +34,7 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/csharp/release.yaml
+++ b/tasks/csharp/release.yaml
@@ -50,7 +50,7 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/cwp/pullrequest.yaml
+++ b/tasks/cwp/pullrequest.yaml
@@ -55,7 +55,7 @@ spec:
           script: |
             #!/bin/sh
             mvn --no-transfer-progress install
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/cwp/release.yaml
+++ b/tasks/cwp/release.yaml
@@ -73,7 +73,7 @@ spec:
           script: |
             #!/bin/sh
             mvn --no-transfer-progress clean deploy
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - env:

--- a/tasks/docker-helm/pullrequest.yaml
+++ b/tasks/docker-helm/pullrequest.yaml
@@ -34,7 +34,7 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/docker-helm/release.yaml
+++ b/tasks/docker-helm/release.yaml
@@ -50,7 +50,7 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/docker/pullrequest.yaml
+++ b/tasks/docker/pullrequest.yaml
@@ -34,7 +34,7 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/docker/release.yaml
+++ b/tasks/docker/release.yaml
@@ -50,7 +50,7 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/go-cli/pullrequest.yaml
+++ b/tasks/go-cli/pullrequest.yaml
@@ -47,7 +47,7 @@ spec:
           script: |
             #!/bin/sh
             make test
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/go-cli/release.yaml
+++ b/tasks/go-cli/release.yaml
@@ -75,7 +75,7 @@ spec:
             export GOVERSION="$(go version | sed -e 's/^[^0-9.]*\([0-9.]*\).*/\1/')"
             export ROOTPACKAGE="github.com/$REPO_OWNER/$REPO_NAME"
             goreleaser release
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/go-mongodb/pullrequest.yaml
+++ b/tasks/go-mongodb/pullrequest.yaml
@@ -41,7 +41,7 @@ spec:
             #!/bin/bash
             source .jx/variables.sh
             make linux
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/go-mongodb/release.yaml
+++ b/tasks/go-mongodb/release.yaml
@@ -57,7 +57,7 @@ spec:
             #!/bin/bash
             source .jx/variables.sh
             make build
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/go-plugin-multiarch/pullrequest.yaml
+++ b/tasks/go-plugin-multiarch/pullrequest.yaml
@@ -53,7 +53,7 @@ spec:
           script: |
             #!/bin/sh
             make test
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/go-plugin/pullrequest.yaml
+++ b/tasks/go-plugin/pullrequest.yaml
@@ -53,7 +53,7 @@ spec:
             #!/bin/bash
             source .jx/variables.sh
             make test
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/go/pullrequest.yaml
+++ b/tasks/go/pullrequest.yaml
@@ -47,7 +47,7 @@ spec:
           script: |
             #!/bin/sh
             golangci-lint run
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/go/release.yaml
+++ b/tasks/go/release.yaml
@@ -57,7 +57,7 @@ spec:
             #!/bin/bash
             source .jx/variables.sh
             make build
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/gradle/pullrequest.yaml
+++ b/tasks/gradle/pullrequest.yaml
@@ -40,7 +40,7 @@ spec:
           script: |
             #!/bin/sh
             gradle clean build
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/gradle/release.yaml
+++ b/tasks/gradle/release.yaml
@@ -56,7 +56,7 @@ spec:
           script: |
             #!/bin/sh
             gradle clean build
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/javascript-ui-nginx/pullrequest.yaml
+++ b/tasks/javascript-ui-nginx/pullrequest.yaml
@@ -52,7 +52,7 @@ spec:
           script: |
             #!/bin/sh
             npm run build
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/javascript-ui-nginx/release.yaml
+++ b/tasks/javascript-ui-nginx/release.yaml
@@ -73,7 +73,7 @@ spec:
           script: |
             #!/bin/sh
             npm run build
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/javascript-yarn/pullrequest.yaml
+++ b/tasks/javascript-yarn/pullrequest.yaml
@@ -51,7 +51,7 @@ spec:
           script: |
             #!/bin/sh
             CI=true DISPLAY=:99 yarn test
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/javascript-yarn/release.yaml
+++ b/tasks/javascript-yarn/release.yaml
@@ -67,7 +67,7 @@ spec:
           script: |
             #!/bin/sh
             CI=true DISPLAY=:99 yarn test
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/javascript/pullrequest.yaml
+++ b/tasks/javascript/pullrequest.yaml
@@ -51,7 +51,7 @@ spec:
           script: |
             #!/bin/sh
             CI=true DISPLAY=:99 npm test
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/javascript/release.yaml
+++ b/tasks/javascript/release.yaml
@@ -67,7 +67,7 @@ spec:
           script: |
             #!/bin/sh
             CI=true DISPLAY=:99 npm test
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/jenkins/pullrequest.yaml
+++ b/tasks/jenkins/pullrequest.yaml
@@ -42,7 +42,7 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/jenkins/release.yaml
+++ b/tasks/jenkins/release.yaml
@@ -58,7 +58,7 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/maven-java11/pullrequest.yaml
+++ b/tasks/maven-java11/pullrequest.yaml
@@ -57,7 +57,7 @@ spec:
             #!/usr/bin/env bash
             source .jx/variables.sh
             mvn --no-transfer-progress install
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/maven-java11/release.yaml
+++ b/tasks/maven-java11/release.yaml
@@ -86,7 +86,7 @@ spec:
             mvn versions:set -DnewVersion=$VERSION
 
             mvn --no-transfer-progress deploy
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/maven-java14/pullrequest.yaml
+++ b/tasks/maven-java14/pullrequest.yaml
@@ -53,7 +53,7 @@ spec:
             #!/usr/bin/env bash
             source .jx/variables.sh
             mvn --no-transfer-progress install
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/maven-java14/release.yaml
+++ b/tasks/maven-java14/release.yaml
@@ -82,7 +82,7 @@ spec:
             mvn versions:set -DnewVersion=$VERSION
 
             mvn --no-transfer-progress deploy
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/maven-java16/pullrequest.yaml
+++ b/tasks/maven-java16/pullrequest.yaml
@@ -53,7 +53,7 @@ spec:
             #!/usr/bin/env bash
             source .jx/variables.sh
             mvn --no-transfer-progress install
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/maven-java16/release.yaml
+++ b/tasks/maven-java16/release.yaml
@@ -82,7 +82,7 @@ spec:
             mvn versions:set -DnewVersion=$VERSION
 
             mvn --no-transfer-progress deploy
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/maven-java17/pullrequest.yaml
+++ b/tasks/maven-java17/pullrequest.yaml
@@ -53,7 +53,7 @@ spec:
             #!/usr/bin/env bash
             source .jx/variables.sh
             mvn --no-transfer-progress install
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/maven-java17/release.yaml
+++ b/tasks/maven-java17/release.yaml
@@ -82,7 +82,7 @@ spec:
             mvn versions:set -DnewVersion=$VERSION
 
             mvn --no-transfer-progress deploy
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/maven-java21/pullrequest.yaml
+++ b/tasks/maven-java21/pullrequest.yaml
@@ -53,7 +53,7 @@ spec:
             #!/usr/bin/env bash
             source .jx/variables.sh
             mvn --no-transfer-progress install
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/maven-java21/release.yaml
+++ b/tasks/maven-java21/release.yaml
@@ -82,7 +82,7 @@ spec:
             mvn versions:set -DnewVersion=$VERSION
 
             mvn --no-transfer-progress deploy
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/maven-node-ruby/pullrequest.yaml
+++ b/tasks/maven-node-ruby/pullrequest.yaml
@@ -59,7 +59,7 @@ spec:
             #!/usr/bin/env bash
             source .jx/variables.sh
             mvn --no-transfer-progress install
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/maven-node-ruby/release.yaml
+++ b/tasks/maven-node-ruby/release.yaml
@@ -87,7 +87,7 @@ spec:
             mvn versions:set -DnewVersion=$VERSION
 
             mvn --no-transfer-progress deploy
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/maven-quarkus-native/pullrequest.yaml
+++ b/tasks/maven-quarkus-native/pullrequest.yaml
@@ -57,7 +57,7 @@ spec:
           script: |
             #!/bin/sh
             mvn --no-transfer-progress install
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/maven-quarkus-native/release.yaml
+++ b/tasks/maven-quarkus-native/release.yaml
@@ -85,7 +85,7 @@ spec:
             mvn versions:set -DnewVersion=$VERSION
 
             mvn --no-transfer-progress deploy -Pnative
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/maven-quarkus/pullrequest.yaml
+++ b/tasks/maven-quarkus/pullrequest.yaml
@@ -57,7 +57,7 @@ spec:
           script: |
             #!/bin/sh
             mvn --no-transfer-progress install
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/maven-quarkus/release.yaml
+++ b/tasks/maven-quarkus/release.yaml
@@ -86,7 +86,7 @@ spec:
             mvn versions:set -DnewVersion=$VERSION
 
             mvn --no-transfer-progress deploy
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/maven/pullrequest.yaml
+++ b/tasks/maven/pullrequest.yaml
@@ -58,7 +58,7 @@ spec:
             #!/usr/bin/env bash
             source .jx/variables.sh
             mvn --no-transfer-progress install
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/maven/release.yaml
+++ b/tasks/maven/release.yaml
@@ -87,7 +87,7 @@ spec:
             mvn versions:set -DnewVersion=$VERSION
 
             mvn --no-transfer-progress deploy
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/ml-python-gpu-service/pullrequest.yaml
+++ b/tasks/ml-python-gpu-service/pullrequest.yaml
@@ -56,7 +56,7 @@ spec:
             #!/bin/sh
             source /root/.bashrc
             pytest
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/ml-python-gpu-service/release.yaml
+++ b/tasks/ml-python-gpu-service/release.yaml
@@ -71,7 +71,7 @@ spec:
             #!/bin/sh
             source /root/.bashrc
             pytest
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/ml-python-service/pullrequest.yaml
+++ b/tasks/ml-python-service/pullrequest.yaml
@@ -56,7 +56,7 @@ spec:
             #!/bin/sh
             source /root/.bashrc
             pytest
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/ml-python-service/release.yaml
+++ b/tasks/ml-python-service/release.yaml
@@ -71,7 +71,7 @@ spec:
             #!/bin/sh
             source /root/.bashrc
             pytest
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/php/pullrequest.yaml
+++ b/tasks/php/pullrequest.yaml
@@ -34,7 +34,7 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/php/release.yaml
+++ b/tasks/php/release.yaml
@@ -50,7 +50,7 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/python/pullrequest.yaml
+++ b/tasks/python/pullrequest.yaml
@@ -40,7 +40,7 @@ spec:
           script: |
             #!/bin/sh
             python -m unittest
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/python/release.yaml
+++ b/tasks/python/release.yaml
@@ -56,7 +56,7 @@ spec:
           script: |
             #!/bin/sh
             python -m unittest
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/ruby/pullrequest.yaml
+++ b/tasks/ruby/pullrequest.yaml
@@ -34,7 +34,7 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/ruby/release.yaml
+++ b/tasks/ruby/release.yaml
@@ -50,7 +50,7 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/rust/pullrequest.yaml
+++ b/tasks/rust/pullrequest.yaml
@@ -40,7 +40,7 @@ spec:
           script: |
             #!/bin/sh
             cargo install --path .
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/rust/release.yaml
+++ b/tasks/rust/release.yaml
@@ -56,7 +56,7 @@ spec:
           script: |
             #!/bin/sh
             cargo install --path .
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/scala/pullrequest.yaml
+++ b/tasks/scala/pullrequest.yaml
@@ -48,7 +48,7 @@ spec:
           script: |
             #!/bin/sh
             sbt clean compile assembly
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/scala/release.yaml
+++ b/tasks/scala/release.yaml
@@ -64,7 +64,7 @@ spec:
           script: |
             #!/bin/sh
             sbt clean compile assembly
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/typescript/pullrequest.yaml
+++ b/tasks/typescript/pullrequest.yaml
@@ -48,7 +48,7 @@ spec:
           script: |
             #!/bin/sh
             CI=true DISPLAY=:99 npm test
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug

--- a/tasks/typescript/release.yaml
+++ b/tasks/typescript/release.yaml
@@ -67,7 +67,7 @@ spec:
           script: |
             #!/bin/sh
             CI=true DISPLAY=:99 npm test
-        - image: ghcr.io/jenkins-x/jx-registry:0.1.12
+        - image: ghcr.io/jenkins-x/jx-registry:0.1.11
           name: check-registry
           resources: {}
         - image: gcr.io/kaniko-project/executor:v1.9.1-debug


### PR DESCRIPTION
The new jx-registry wasn't supposed to have any functional changes. But it has become appealingly slow

Reverts jenkins-x/jx3-pipeline-catalog#1608