### PR TITLE
chore(golang): avoid error tektoncd/pipeline@v1.1.0 requires go >= 1.24.0

### DIFF
--- a/tasks/go-cli/pullrequest.yaml
+++ b/tasks/go-cli/pullrequest.yaml
@@ -34,14 +34,14 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: golang:1.23.2@sha256:a7f2fc9834049c1f5df787690026a53738e55fc097cd8a4a93faa3e06c67ee32
+        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
           name: build-make-linux
           resources: {}
           script: |
             #!/bin/bash
             source .jx/variables.sh
             make linux
-        - image: golang:1.23.2@sha256:a7f2fc9834049c1f5df787690026a53738e55fc097cd8a4a93faa3e06c67ee32
+        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
           name: build-make-test
           resources: {}
           script: |

--- a/tasks/go-cli/release.yaml
+++ b/tasks/go-cli/release.yaml
@@ -56,7 +56,7 @@ spec:
               secretKeyRef:
                 key: password
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-goreleaser-image:1.0.0@sha256:35070795367fea9a789c1c3a138b5e32262e4253d38e47406ba9ab7833ff15b2
+          image: ghcr.io/jenkins-x/jx-goreleaser-image:1.0.2@sha256:7632b381687494e910e06a88b3801e39c1f17fbb44402db3cef45b2b342204e1
           name: upload-binaries
           resources: {}
           script: |

--- a/tasks/go-mongodb/pullrequest.yaml
+++ b/tasks/go-mongodb/pullrequest.yaml
@@ -34,7 +34,7 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: golang:1.23.2@sha256:a7f2fc9834049c1f5df787690026a53738e55fc097cd8a4a93faa3e06c67ee32
+        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
           name: build-make-linux
           resources: {}
           script: |

--- a/tasks/go-mongodb/release.yaml
+++ b/tasks/go-mongodb/release.yaml
@@ -50,7 +50,7 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: golang:1.23.2@sha256:a7f2fc9834049c1f5df787690026a53738e55fc097cd8a4a93faa3e06c67ee32
+        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
           name: build-make-build
           resources: {}
           script: |

--- a/tasks/go-plugin-multiarch/pullrequest.yaml
+++ b/tasks/go-plugin-multiarch/pullrequest.yaml
@@ -34,20 +34,20 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: golang:1.23.2@sha256:a7f2fc9834049c1f5df787690026a53738e55fc097cd8a4a93faa3e06c67ee32
+        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
           name: build-make-linux
           resources: {}
           script: |
             #!/bin/bash
             source .jx/variables.sh
             make linux
-        - image: golangci/golangci-lint:v1.61.0-alpine@sha256:61e2d68adc792393fcb600340fe5c28059638d813869d5b4c9502392a2fb4c96
+        - image: golangci/golangci-lint:v1.64.8-alpine@sha256:ae6460f78db54f22838d2a8aee0f2eaa4f785d5a01f638600072b60848f8deb4
           name: make-lint
           resources: {}
           script: |
             #!/bin/sh
             golangci-lint run
-        - image: golang:1.23.2@sha256:a7f2fc9834049c1f5df787690026a53738e55fc097cd8a4a93faa3e06c67ee32
+        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
           name: build-make-test
           resources: {}
           script: |

--- a/tasks/go-plugin-multiarch/release.yaml
+++ b/tasks/go-plugin-multiarch/release.yaml
@@ -45,7 +45,7 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: golang:1.23.2@sha256:a7f2fc9834049c1f5df787690026a53738e55fc097cd8a4a93faa3e06c67ee32
+        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
           name: release-binary
           resources: {}
           script: |
@@ -96,7 +96,7 @@ spec:
               secretKeyRef:
                 key: password
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-goreleaser-image:1.0.0@sha256:35070795367fea9a789c1c3a138b5e32262e4253d38e47406ba9ab7833ff15b2
+          image: ghcr.io/jenkins-x/jx-goreleaser-image:1.0.2@sha256:7632b381687494e910e06a88b3801e39c1f17fbb44402db3cef45b2b342204e1
           name: upload-binaries
           resources: {}
           script: |

--- a/tasks/go-plugin/pullrequest.yaml
+++ b/tasks/go-plugin/pullrequest.yaml
@@ -34,19 +34,19 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: golang:1.23.2@sha256:a7f2fc9834049c1f5df787690026a53738e55fc097cd8a4a93faa3e06c67ee32
+        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
           name: build-make-linux
           resources: {}
           script: |
             #!/bin/sh
             make linux
-        - image: golangci/golangci-lint:v1.61.0-alpine@sha256:61e2d68adc792393fcb600340fe5c28059638d813869d5b4c9502392a2fb4c96
+        - image: golangci/golangci-lint:v1.64.8-alpine@sha256:ae6460f78db54f22838d2a8aee0f2eaa4f785d5a01f638600072b60848f8deb4
           name: make-lint
           resources: {}
           script: |
             #!/bin/sh
             golangci-lint run
-        - image: golang:1.23.2@sha256:a7f2fc9834049c1f5df787690026a53738e55fc097cd8a4a93faa3e06c67ee32
+        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
           name: build-make-test
           resources: {}
           script: |

--- a/tasks/go-plugin/release.yaml
+++ b/tasks/go-plugin/release.yaml
@@ -49,7 +49,7 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: golang:1.23.2@sha256:a7f2fc9834049c1f5df787690026a53738e55fc097cd8a4a93faa3e06c67ee32
+        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
           name: release-binary
           resources: {}
           script: |
@@ -100,7 +100,7 @@ spec:
               secretKeyRef:
                 key: password
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-goreleaser-image:1.0.0@sha256:35070795367fea9a789c1c3a138b5e32262e4253d38e47406ba9ab7833ff15b2
+          image: ghcr.io/jenkins-x/jx-goreleaser-image:1.0.2@sha256:7632b381687494e910e06a88b3801e39c1f17fbb44402db3cef45b2b342204e1
           name: upload-binaries
           resources: {}
           script: |

--- a/tasks/go/pullrequest.yaml
+++ b/tasks/go/pullrequest.yaml
@@ -34,14 +34,14 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: golang:1.23.2@sha256:a7f2fc9834049c1f5df787690026a53738e55fc097cd8a4a93faa3e06c67ee32
+        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
           name: build-make-linux
           resources: {}
           script: |
             #!/bin/bash
             source .jx/variables.sh
             make linux
-        - image: golangci/golangci-lint:v1.61.0-alpine@sha256:61e2d68adc792393fcb600340fe5c28059638d813869d5b4c9502392a2fb4c96
+        - image: golangci/golangci-lint:v1.64.8-alpine@sha256:ae6460f78db54f22838d2a8aee0f2eaa4f785d5a01f638600072b60848f8deb4
           name: make-lint
           resources: {}
           script: |

--- a/tasks/go/release.yaml
+++ b/tasks/go/release.yaml
@@ -50,7 +50,7 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: golang:1.23.2@sha256:a7f2fc9834049c1f5df787690026a53738e55fc097cd8a4a93faa3e06c67ee32
+        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
           name: build-make-build
           resources: {}
           script: |


### PR DESCRIPTION
related to https://github.com/jenkins-x/lighthouse/pull/1650