### PR TITLE
fix: tekton is overwriting ~/.gitconfig

### DIFF
--- a/tasks/git-clone/git-clone-env-pr-partial.yaml
+++ b/tasks/git-clone/git-clone-env-pr-partial.yaml
@@ -26,9 +26,6 @@ spec:
         #!/bin/sh
         export SUBDIR="source"
         echo "git cloning url: $REPO_URL version $PULL_PULL_REF:$(echo $JOB_NAME | tr '[:lower:]' '[:upper:]')-$PULL_NUMBER@$PULL_PULL_SHA to dir: $SUBDIR"
-        git config --global --add user.name ${GIT_AUTHOR_NAME:-jenkins-x-bot}
-        git config --global --add user.email ${GIT_AUTHOR_EMAIL:-jenkins-x@googlegroups.com}
-        git config --global credential.helper store
         # Use a treeless clone to checkout only the desired commit
         # Useful for large git repositories using single-build pipelines
         git clone  --filter=tree:0 --no-checkout "$REPO_URL" "$SUBDIR"
@@ -37,6 +34,8 @@ spec:
         git checkout $(echo $JOB_NAME | tr '[:lower:]' '[:upper:]')-$PULL_NUMBER
         git branch
         git reset --hard $PULL_PULL_SHA
+        git config --add user.name ${GIT_AUTHOR_NAME:-jenkins-x-bot}
+        git config --add user.email ${GIT_AUTHOR_EMAIL:-jenkins-x@googlegroups.com}
         echo "checked out revision: $PULL_PULL_REF:$(echo $JOB_NAME | tr '[:lower:]' '[:upper:]')-$PULL_NUMBER@$PULL_PULL_SHA to dir: $SUBDIR"
       workingDir: /workspace
     - envFrom:

--- a/tasks/git-clone/git-clone-env-pr.yaml
+++ b/tasks/git-clone/git-clone-env-pr.yaml
@@ -26,14 +26,13 @@ spec:
       #!/bin/sh
       export SUBDIR="source"
       echo "git cloning url: $REPO_URL version $PULL_PULL_REF:$(echo $JOB_NAME | tr '[:lower:]' '[:upper:]')-$PULL_NUMBER@$PULL_PULL_SHA to dir: $SUBDIR"
-      git config --global --add user.name ${GIT_AUTHOR_NAME:-jenkins-x-bot}
-      git config --global --add user.email ${GIT_AUTHOR_EMAIL:-jenkins-x@googlegroups.com}
-      git config --global credential.helper store
       git clone $REPO_URL $SUBDIR
       cd $SUBDIR
       git fetch origin $PULL_PULL_REF:$(echo $JOB_NAME | tr '[:lower:]' '[:upper:]')-$PULL_NUMBER
       git checkout $(echo $JOB_NAME | tr '[:lower:]' '[:upper:]')-$PULL_NUMBER
       git reset --hard $PULL_PULL_SHA
+      git config --add user.name ${GIT_AUTHOR_NAME:-jenkins-x-bot}
+      git config --add user.email ${GIT_AUTHOR_EMAIL:-jenkins-x@googlegroups.com}
       echo "checked out revision: $PULL_PULL_REF:$(echo $JOB_NAME | tr '[:lower:]' '[:upper:]')-$PULL_NUMBER@$PULL_PULL_SHA to dir: $SUBDIR"
     workingDir: /workspace
   - envFrom:

--- a/tasks/git-clone/git-clone-pr.yaml
+++ b/tasks/git-clone/git-clone-pr.yaml
@@ -27,14 +27,13 @@ spec:
       #!/bin/sh
       export SUBDIR="source"
       echo "git cloning url: $REPO_URL version $PULL_PULL_REF:$(echo $JOB_NAME | tr '[:lower:]' '[:upper:]')-$PULL_NUMBER@$PULL_PULL_SHA to dir: $SUBDIR"
-      git config --global --add user.name ${GIT_AUTHOR_NAME:-jenkins-x-bot}
-      git config --global --add user.email ${GIT_AUTHOR_EMAIL:-jenkins-x@googlegroups.com}
-      git config --global credential.helper store
       git clone $REPO_URL $SUBDIR
       cd $SUBDIR
       git fetch origin $PULL_PULL_REF:$(echo $JOB_NAME | tr '[:lower:]' '[:upper:]')-$PULL_NUMBER
       git checkout $(echo $JOB_NAME | tr '[:lower:]' '[:upper:]')-$PULL_NUMBER
       git reset --hard $PULL_PULL_SHA
+      git config --add user.name ${GIT_AUTHOR_NAME:-jenkins-x-bot}
+      git config --add user.email ${GIT_AUTHOR_EMAIL:-jenkins-x@googlegroups.com}
       echo "checked out revision: $PULL_PULL_REF:$(echo $JOB_NAME | tr '[:lower:]' '[:upper:]')-$PULL_NUMBER@$PULL_PULL_SHA to dir: $SUBDIR"
     workingDir: /workspace
   - envFrom:

--- a/tasks/git-clone/git-clone.yaml
+++ b/tasks/git-clone/git-clone.yaml
@@ -26,12 +26,11 @@ spec:
       #!/bin/sh
       export SUBDIR="source"
       echo "git cloning url: $REPO_URL version $PULL_BASE_REF@$PULL_BASE_SHA to dir: $SUBDIR"
-      git config --global --add user.name ${GIT_AUTHOR_NAME:-jenkins-x-bot}
-      git config --global --add user.email ${GIT_AUTHOR_EMAIL:-jenkins-x@googlegroups.com}
-      git config --global credential.helper store
       git clone $REPO_URL $SUBDIR
       cd $SUBDIR
       git reset --hard $PULL_BASE_SHA
+      git config --add user.name ${GIT_AUTHOR_NAME:-jenkins-x-bot}
+      git config --add user.email ${GIT_AUTHOR_EMAIL:-jenkins-x@googlegroups.com}
       echo "checked out revision: $PULL_BASE_REF@$PULL_BASE_SHA to dir: $SUBDIR"
 
     workingDir: /workspace


### PR DESCRIPTION
Tekton v1 is automatically doing the equivalent of `git config --global credential.helper store`, so that isn't needed. Tekton is also reinitializing ~/.gitconfig before each step, so storing user.name and user.email there doesn't work.