### PR TITLE
fix: stop committing .jx/variables.sh in pr pipeline

### DIFF
--- a/tasks/C++/pullrequest.yaml
+++ b/tasks/C++/pullrequest.yaml
@@ -27,7 +27,7 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: cpp
           name: build-cmake

--- a/tasks/D/pullrequest.yaml
+++ b/tasks/D/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 1Gi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: ghcr.io/jenkins-x/builder-dlang:2.1.155-779
           name: build-dub-build

--- a/tasks/apps/pullrequest.yaml
+++ b/tasks/apps/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 600Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: ghcr.io/jenkins-x/builder-go:2.1.155-779
           name: build-build

--- a/tasks/appserver/pullrequest.yaml
+++ b/tasks/appserver/pullrequest.yaml
@@ -40,7 +40,7 @@ spec:
               memory: 512Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: maven:3.6-openjdk-8
           name: build-set-version

--- a/tasks/charts/pullrequest.yaml
+++ b/tasks/charts/pullrequest.yaml
@@ -27,7 +27,7 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: ghcr.io/jenkins-x/builder-go:2.1.155-779
           name: build-build

--- a/tasks/csharp/pullrequest.yaml
+++ b/tasks/csharp/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 256Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: ghcr.io/jenkins-x/jx-registry:0.1.17
           name: check-registry

--- a/tasks/custom-jenkins/pullrequest.yaml
+++ b/tasks/custom-jenkins/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 600Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: ghcr.io/jenkins-x/builder-go:2.1.155-779
           name: build-build

--- a/tasks/cwp/pullrequest.yaml
+++ b/tasks/cwp/pullrequest.yaml
@@ -40,7 +40,7 @@ spec:
               memory: 512Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: maven:3.6-openjdk-8
           name: build-set-version

--- a/tasks/docker-helm/pullrequest.yaml
+++ b/tasks/docker-helm/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 512Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: ghcr.io/jenkins-x/jx-registry:0.1.17
           name: check-registry

--- a/tasks/docker/pullrequest.yaml
+++ b/tasks/docker/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 512Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: ghcr.io/jenkins-x/jx-registry:0.1.17
           name: check-registry

--- a/tasks/flutter/pullrequest.yaml
+++ b/tasks/flutter/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 512Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: mobiledevops/flutter-sdk-image:2.0.1
           name: build

--- a/tasks/go-cli/pullrequest.yaml
+++ b/tasks/go-cli/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 600Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
           name: build-make-linux

--- a/tasks/go-mongodb/pullrequest.yaml
+++ b/tasks/go-mongodb/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 600Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
           name: build-make-linux

--- a/tasks/go-plugin-multiarch/pullrequest.yaml
+++ b/tasks/go-plugin-multiarch/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 3600Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
           name: build-make-linux

--- a/tasks/go-plugin/pullrequest.yaml
+++ b/tasks/go-plugin/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 3600Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
           name: build-make-linux

--- a/tasks/go/pullrequest.yaml
+++ b/tasks/go/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 600Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
           name: build-make-linux

--- a/tasks/gradle/pullrequest.yaml
+++ b/tasks/gradle/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 512Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: gradle:jdk11-openj9
           name: build-gradle-build

--- a/tasks/helm/pullrequest.yaml
+++ b/tasks/helm/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 512Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: ghcr.io/jenkins-x/jx-boot:3.16.20
           name: build-helm-build

--- a/tasks/javascript-ui-nginx/pullrequest.yaml
+++ b/tasks/javascript-ui-nginx/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 512Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: node:20-slim
           name: build-npm-install

--- a/tasks/javascript-yarn/pullrequest.yaml
+++ b/tasks/javascript-yarn/pullrequest.yaml
@@ -37,7 +37,7 @@ spec:
               memory: 512Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: node:22-slim
           name: build-yarn-install

--- a/tasks/javascript/pullrequest.yaml
+++ b/tasks/javascript/pullrequest.yaml
@@ -37,7 +37,7 @@ spec:
               memory: 512Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: node:20-slim
           name: build-npm-install

--- a/tasks/jenkins/pullrequest.yaml
+++ b/tasks/jenkins/pullrequest.yaml
@@ -40,7 +40,7 @@ spec:
               memory: 512Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: ghcr.io/jenkins-x/jx-registry:0.1.17
           name: check-registry

--- a/tasks/jenkinsfilerunner/pullrequest.yaml
+++ b/tasks/jenkinsfilerunner/pullrequest.yaml
@@ -27,7 +27,7 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: jenkins4eval/jenkinsfile-runner
           name: build-run

--- a/tasks/lookml/pullrequest.yaml
+++ b/tasks/lookml/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 512Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: python:3.7-alpine
           name: build-lookml-datatest

--- a/tasks/maven-java11/pullrequest.yaml
+++ b/tasks/maven-java11/pullrequest.yaml
@@ -42,7 +42,7 @@ spec:
               memory: 512Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: maven:3.6-openjdk-11
           name: build-set-version

--- a/tasks/maven-java14/pullrequest.yaml
+++ b/tasks/maven-java14/pullrequest.yaml
@@ -38,7 +38,7 @@ spec:
               memory: 512Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: maven:3.8-openjdk-15
           name: build-set-version

--- a/tasks/maven-java16/pullrequest.yaml
+++ b/tasks/maven-java16/pullrequest.yaml
@@ -38,7 +38,7 @@ spec:
               memory: 512Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: maven:3.8-openjdk-16
           name: build-set-version

--- a/tasks/maven-java17/pullrequest.yaml
+++ b/tasks/maven-java17/pullrequest.yaml
@@ -38,7 +38,7 @@ spec:
               memory: 512Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: maven:3.8.2-openjdk-17
           name: build-set-version

--- a/tasks/maven-java21/pullrequest.yaml
+++ b/tasks/maven-java21/pullrequest.yaml
@@ -38,7 +38,7 @@ spec:
               memory: 512Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: maven:3.9.6-eclipse-temurin-21
           name: build-set-version

--- a/tasks/maven-node-ruby/pullrequest.yaml
+++ b/tasks/maven-node-ruby/pullrequest.yaml
@@ -43,7 +43,7 @@ spec:
               memory: 512Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: maven:3.6-openjdk-8
           name: build-set-version

--- a/tasks/maven-quarkus-native/pullrequest.yaml
+++ b/tasks/maven-quarkus-native/pullrequest.yaml
@@ -42,7 +42,7 @@ spec:
               memory: 2Gi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: ghcr.io/jenkins-x/maven-quarkus-mandrel:0.0.1
           name: build-set-version

--- a/tasks/maven-quarkus/pullrequest.yaml
+++ b/tasks/maven-quarkus/pullrequest.yaml
@@ -42,7 +42,7 @@ spec:
               memory: 2Gi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: ghcr.io/jenkins-x/builder-maven-graalvm:2.1.155-779
           name: build-set-version

--- a/tasks/maven/pullrequest.yaml
+++ b/tasks/maven/pullrequest.yaml
@@ -43,7 +43,7 @@ spec:
               memory: 512Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: maven:3.6-openjdk-8-slim
           name: build-set-version

--- a/tasks/ml-python-gpu-service/pullrequest.yaml
+++ b/tasks/ml-python-gpu-service/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 1Gi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: ghcr.io/jenkins-x/builder-machine-learning-gpu:0.1.1317
           name: build-step2

--- a/tasks/ml-python-gpu-training/pullrequest.yaml
+++ b/tasks/ml-python-gpu-training/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 4Gi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: ghcr.io/jenkins-x/builder-machine-learning:0.1.1317
           name: build-flake8

--- a/tasks/ml-python-service/pullrequest.yaml
+++ b/tasks/ml-python-service/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 4Gi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: ghcr.io/jenkins-x/builder-machine-learning:0.1.1317
           name: build-step2

--- a/tasks/ml-python-training/pullrequest.yaml
+++ b/tasks/ml-python-training/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 4Gi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: ghcr.io/jenkins-x/builder-machine-learning:0.1.1317
           name: build-flake8

--- a/tasks/nop/pullrequest.yaml
+++ b/tasks/nop/pullrequest.yaml
@@ -27,7 +27,7 @@ spec:
           resources: {}
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: ghcr.io/jenkins-x/jx-boot:3.16.20
           name: build-dummy-build

--- a/tasks/php/pullrequest.yaml
+++ b/tasks/php/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 256Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: ghcr.io/jenkins-x/jx-registry:0.1.17
           name: check-registry

--- a/tasks/python/pullrequest.yaml
+++ b/tasks/python/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 512Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: python:3.6.12-alpine
           name: build-python-unittest

--- a/tasks/ruby/pullrequest.yaml
+++ b/tasks/ruby/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 512Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: ghcr.io/jenkins-x/jx-registry:0.1.17
           name: check-registry

--- a/tasks/rust/pullrequest.yaml
+++ b/tasks/rust/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 512Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: rust:1.49.0
           name: build-cargo-install

--- a/tasks/scala/pullrequest.yaml
+++ b/tasks/scala/pullrequest.yaml
@@ -40,7 +40,7 @@ spec:
               memory: 512Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: ghcr.io/jenkins-x/builder-scala:2.1.155-778
           name: build-sbt-assembly

--- a/tasks/terraform/pullrequest.yaml
+++ b/tasks/terraform/pullrequest.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 600Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: ghcr.io/jenkins-x/terraform-operator-gcp
           name: lint

--- a/tasks/typescript/pullrequest.yaml
+++ b/tasks/typescript/pullrequest.yaml
@@ -34,7 +34,7 @@ spec:
               memory: 512Mi
           script: |
             #!/usr/bin/env sh
-            jx gitops variables
+            jx gitops variables --commit=false
             jx gitops pr variables
         - image: node:20-slim
           name: build-npm-install


### PR DESCRIPTION
In the years I've worked with jx I've never seen see what it would be good for and now it causes problems for many:

https://kubernetes.slack.com/archives/C9MBGQJRH/p1754665101896789