### PR TITLE
chore: upgrade golang to version 1.26.3

### DIFF
--- a/tasks/go-cli/pullrequest.yaml
+++ b/tasks/go-cli/pullrequest.yaml
@@ -34,14 +34,14 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables --commit=false
             jx gitops pr variables
-        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
+        - image: golang:1.26.3@sha256:2981696eed011d747340d7252620932677929cce7d2d539602f56a8d7e9b660b
           name: build-make-linux
           resources: {}
           script: |
             #!/bin/bash
             source .jx/variables.sh
             make linux
-        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
+        - image: golang:1.26.3@sha256:2981696eed011d747340d7252620932677929cce7d2d539602f56a8d7e9b660b
           name: build-make-test
           resources: {}
           script: |

--- a/tasks/go-cli/release.yaml
+++ b/tasks/go-cli/release.yaml
@@ -56,7 +56,7 @@ spec:
               secretKeyRef:
                 key: password
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-goreleaser-image:1.0.2@sha256:7632b381687494e910e06a88b3801e39c1f17fbb44402db3cef45b2b342204e1
+          image: ghcr.io/jenkins-x/jx-goreleaser-image:1.0.3@sha256:f304b286bf8c0995b8161172eb54ab12bcd744f89caf71fc3a91329de87a3b4f
           name: upload-binaries
           resources: {}
           script: |

--- a/tasks/go-mongodb/pullrequest.yaml
+++ b/tasks/go-mongodb/pullrequest.yaml
@@ -34,7 +34,7 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables --commit=false
             jx gitops pr variables
-        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
+        - image: golang:1.26.3@sha256:2981696eed011d747340d7252620932677929cce7d2d539602f56a8d7e9b660b
           name: build-make-linux
           resources: {}
           script: |

--- a/tasks/go-mongodb/release.yaml
+++ b/tasks/go-mongodb/release.yaml
@@ -50,7 +50,7 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
+        - image: golang:1.26.3@sha256:2981696eed011d747340d7252620932677929cce7d2d539602f56a8d7e9b660b
           name: build-make-build
           resources: {}
           script: |

--- a/tasks/go-plugin-multiarch/pullrequest.yaml
+++ b/tasks/go-plugin-multiarch/pullrequest.yaml
@@ -34,7 +34,7 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables --commit=false
             jx gitops pr variables
-        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
+        - image: golang:1.26.3@sha256:2981696eed011d747340d7252620932677929cce7d2d539602f56a8d7e9b660b
           name: build-make-linux
           resources: {}
           script: |
@@ -47,7 +47,7 @@ spec:
           script: |
             #!/bin/sh
             golangci-lint run
-        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
+        - image: golang:1.26.3@sha256:2981696eed011d747340d7252620932677929cce7d2d539602f56a8d7e9b660b
           name: build-make-test
           resources: {}
           script: |

--- a/tasks/go-plugin-multiarch/release.yaml
+++ b/tasks/go-plugin-multiarch/release.yaml
@@ -49,7 +49,7 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
+        - image: golang:1.26.3@sha256:2981696eed011d747340d7252620932677929cce7d2d539602f56a8d7e9b660b
           name: release-binary
           resources: {}
           script: |

--- a/tasks/go-plugin-multiarch/release.yaml
+++ b/tasks/go-plugin-multiarch/release.yaml
@@ -100,7 +100,7 @@ spec:
               secretKeyRef:
                 key: password
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-goreleaser-image:1.0.2@sha256:7632b381687494e910e06a88b3801e39c1f17fbb44402db3cef45b2b342204e1
+          image: ghcr.io/jenkins-x/jx-goreleaser-image:1.0.3@sha256:f304b286bf8c0995b8161172eb54ab12bcd744f89caf71fc3a91329de87a3b4f
           name: upload-binaries
           resources: {}
           script: |

--- a/tasks/go-plugin/pullrequest.yaml
+++ b/tasks/go-plugin/pullrequest.yaml
@@ -34,7 +34,7 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables --commit=false
             jx gitops pr variables
-        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
+        - image: golang:1.26.3@sha256:2981696eed011d747340d7252620932677929cce7d2d539602f56a8d7e9b660b
           name: build-make-linux
           resources: {}
           script: |
@@ -46,7 +46,7 @@ spec:
           script: |
             #!/bin/sh
             golangci-lint run
-        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
+        - image: golang:1.26.3@sha256:2981696eed011d747340d7252620932677929cce7d2d539602f56a8d7e9b660b
           name: build-make-test
           resources: {}
           script: |

--- a/tasks/go-plugin/release.yaml
+++ b/tasks/go-plugin/release.yaml
@@ -49,7 +49,7 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
+        - image: golang:1.26.3@sha256:2981696eed011d747340d7252620932677929cce7d2d539602f56a8d7e9b660b
           name: release-binary
           resources: {}
           script: |

--- a/tasks/go-plugin/release.yaml
+++ b/tasks/go-plugin/release.yaml
@@ -100,7 +100,7 @@ spec:
               secretKeyRef:
                 key: password
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-goreleaser-image:1.0.2@sha256:7632b381687494e910e06a88b3801e39c1f17fbb44402db3cef45b2b342204e1
+          image: ghcr.io/jenkins-x/jx-goreleaser-image:1.0.3@sha256:f304b286bf8c0995b8161172eb54ab12bcd744f89caf71fc3a91329de87a3b4f
           name: upload-binaries
           resources: {}
           script: |

--- a/tasks/go/pullrequest.yaml
+++ b/tasks/go/pullrequest.yaml
@@ -34,7 +34,7 @@ spec:
             #!/usr/bin/env sh
             jx gitops variables --commit=false
             jx gitops pr variables
-        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
+        - image: golang:1.26.3@sha256:2981696eed011d747340d7252620932677929cce7d2d539602f56a8d7e9b660b
           name: build-make-linux
           resources: {}
           script: |

--- a/tasks/go/release.yaml
+++ b/tasks/go/release.yaml
@@ -50,7 +50,7 @@ spec:
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: golang:1.24.4@sha256:d1db785fb37feb87d9140d78ed4fb7c75ee787360366a9c5efe39c7a841a0277
+        - image: golang:1.26.3@sha256:2981696eed011d747340d7252620932677929cce7d2d539602f56a8d7e9b660b
           name: build-make-build
           resources: {}
           script: |


### PR DESCRIPTION
Find and replace across all tasks updating golang image from 1.24.4 -> 1.26.3

Reference issue https://github.com/jenkins-x/jx/issues/8965