### PR TITLE
feat: add HTTPRoutes to packs as Ingress alternatives

### DIFF
--- a/helm/charts/templates/httproute.yaml
+++ b/helm/charts/templates/httproute.yaml
@@ -1,0 +1,55 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/helm/charts/templates/ingress.yaml
+++ b/helm/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/helm/charts/values.yaml
+++ b/helm/charts/values.yaml
@@ -105,6 +105,24 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""
@@ -122,6 +140,8 @@ jxRequirements:
     #  kubernetes.io/ingress.class: nginx
 
     apiVersion: "networking.k8s.io/v1"
+
+    kind: ""
 
     # the domain for hosts
     domain: ""

--- a/packs/C++/charts/templates/httproute.yaml
+++ b/packs/C++/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/C++/charts/templates/httproute.yaml
+++ b/packs/C++/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/C++/charts/templates/httproute.yaml
+++ b/packs/C++/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/C++/charts/templates/ingress.yaml
+++ b/packs/C++/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/C++/charts/values.yaml
+++ b/packs/C++/charts/values.yaml
@@ -112,13 +112,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/C++/charts/values.yaml
+++ b/packs/C++/charts/values.yaml
@@ -139,6 +139,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/C++/charts/values.yaml
+++ b/packs/C++/charts/values.yaml
@@ -105,6 +105,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/C++/charts/values.yaml
+++ b/packs/C++/charts/values.yaml
@@ -112,8 +112,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/C++/preview/Kptfile
+++ b/packs/C++/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/D/charts/templates/httproute.yaml
+++ b/packs/D/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/D/charts/templates/httproute.yaml
+++ b/packs/D/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/D/charts/templates/httproute.yaml
+++ b/packs/D/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/D/charts/templates/ingress.yaml
+++ b/packs/D/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/D/charts/values.yaml
+++ b/packs/D/charts/values.yaml
@@ -112,13 +112,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/D/charts/values.yaml
+++ b/packs/D/charts/values.yaml
@@ -139,6 +139,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/D/charts/values.yaml
+++ b/packs/D/charts/values.yaml
@@ -105,6 +105,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/D/charts/values.yaml
+++ b/packs/D/charts/values.yaml
@@ -112,8 +112,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/D/preview/Kptfile
+++ b/packs/D/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/appserver/charts/templates/httproute.yaml
+++ b/packs/appserver/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/appserver/charts/templates/httproute.yaml
+++ b/packs/appserver/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/appserver/charts/templates/httproute.yaml
+++ b/packs/appserver/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/appserver/charts/templates/ingress.yaml
+++ b/packs/appserver/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/appserver/charts/values.yaml
+++ b/packs/appserver/charts/values.yaml
@@ -112,13 +112,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/appserver/charts/values.yaml
+++ b/packs/appserver/charts/values.yaml
@@ -139,6 +139,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/appserver/charts/values.yaml
+++ b/packs/appserver/charts/values.yaml
@@ -105,6 +105,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/appserver/charts/values.yaml
+++ b/packs/appserver/charts/values.yaml
@@ -112,8 +112,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/appserver/preview/Kptfile
+++ b/packs/appserver/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/csharp/charts/templates/httproute.yaml
+++ b/packs/csharp/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/csharp/charts/templates/httproute.yaml
+++ b/packs/csharp/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/csharp/charts/templates/httproute.yaml
+++ b/packs/csharp/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/csharp/charts/templates/ingress.yaml
+++ b/packs/csharp/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/csharp/charts/values.yaml
+++ b/packs/csharp/charts/values.yaml
@@ -112,13 +112,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/csharp/charts/values.yaml
+++ b/packs/csharp/charts/values.yaml
@@ -139,6 +139,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/csharp/charts/values.yaml
+++ b/packs/csharp/charts/values.yaml
@@ -105,6 +105,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/csharp/charts/values.yaml
+++ b/packs/csharp/charts/values.yaml
@@ -112,8 +112,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/csharp/preview/Kptfile
+++ b/packs/csharp/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/cwp/charts/templates/httproute.yaml
+++ b/packs/cwp/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/cwp/charts/templates/httproute.yaml
+++ b/packs/cwp/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/cwp/charts/templates/httproute.yaml
+++ b/packs/cwp/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/cwp/charts/templates/ingress.yaml
+++ b/packs/cwp/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/cwp/charts/values.yaml
+++ b/packs/cwp/charts/values.yaml
@@ -105,6 +105,23 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
+
 serviceAccount:
   enabled: true
   name: ""
@@ -120,6 +137,8 @@ jxRequirements:
     # shared ingress annotations on all services
     annotations: {}
     #  kubernetes.io/ingress.class: nginx
+
+    kind: ""
 
     apiVersion: "networking.k8s.io/v1"
 

--- a/packs/cwp/charts/values.yaml
+++ b/packs/cwp/charts/values.yaml
@@ -112,8 +112,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/cwp/charts/values.yaml
+++ b/packs/cwp/charts/values.yaml
@@ -112,13 +112,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 

--- a/packs/cwp/preview/Kptfile
+++ b/packs/cwp/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/go-mongodb/charts/templates/httproute.yaml
+++ b/packs/go-mongodb/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/go-mongodb/charts/templates/httproute.yaml
+++ b/packs/go-mongodb/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/go-mongodb/charts/templates/httproute.yaml
+++ b/packs/go-mongodb/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/go-mongodb/charts/templates/ingress.yaml
+++ b/packs/go-mongodb/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/go-mongodb/charts/values.yaml
+++ b/packs/go-mongodb/charts/values.yaml
@@ -112,13 +112,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/go-mongodb/charts/values.yaml
+++ b/packs/go-mongodb/charts/values.yaml
@@ -139,6 +139,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/go-mongodb/charts/values.yaml
+++ b/packs/go-mongodb/charts/values.yaml
@@ -105,6 +105,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/go-mongodb/charts/values.yaml
+++ b/packs/go-mongodb/charts/values.yaml
@@ -112,8 +112,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/go-mongodb/preview/Kptfile
+++ b/packs/go-mongodb/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/go/charts/templates/httproute.yaml
+++ b/packs/go/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/go/charts/templates/httproute.yaml
+++ b/packs/go/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/go/charts/templates/httproute.yaml
+++ b/packs/go/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/go/charts/templates/ingress.yaml
+++ b/packs/go/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/go/charts/values.yaml
+++ b/packs/go/charts/values.yaml
@@ -112,13 +112,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/go/charts/values.yaml
+++ b/packs/go/charts/values.yaml
@@ -139,6 +139,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/go/charts/values.yaml
+++ b/packs/go/charts/values.yaml
@@ -105,6 +105,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/go/charts/values.yaml
+++ b/packs/go/charts/values.yaml
@@ -112,8 +112,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/go/preview/Kptfile
+++ b/packs/go/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/gradle/charts/templates/httproute.yaml
+++ b/packs/gradle/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/gradle/charts/templates/httproute.yaml
+++ b/packs/gradle/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/gradle/charts/templates/httproute.yaml
+++ b/packs/gradle/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/gradle/charts/templates/ingress.yaml
+++ b/packs/gradle/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/gradle/charts/values.yaml
+++ b/packs/gradle/charts/values.yaml
@@ -112,13 +112,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/gradle/charts/values.yaml
+++ b/packs/gradle/charts/values.yaml
@@ -139,6 +139,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/gradle/charts/values.yaml
+++ b/packs/gradle/charts/values.yaml
@@ -105,6 +105,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/gradle/charts/values.yaml
+++ b/packs/gradle/charts/values.yaml
@@ -112,8 +112,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/gradle/preview/Kptfile
+++ b/packs/gradle/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/javascript-ui-nginx/charts/templates/httproute.yaml
+++ b/packs/javascript-ui-nginx/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/javascript-ui-nginx/charts/templates/httproute.yaml
+++ b/packs/javascript-ui-nginx/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/javascript-ui-nginx/charts/templates/httproute.yaml
+++ b/packs/javascript-ui-nginx/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/javascript-ui-nginx/charts/templates/ingress.yaml
+++ b/packs/javascript-ui-nginx/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/javascript-ui-nginx/charts/values.yaml
+++ b/packs/javascript-ui-nginx/charts/values.yaml
@@ -112,13 +112,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/javascript-ui-nginx/charts/values.yaml
+++ b/packs/javascript-ui-nginx/charts/values.yaml
@@ -139,6 +139,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/javascript-ui-nginx/charts/values.yaml
+++ b/packs/javascript-ui-nginx/charts/values.yaml
@@ -105,6 +105,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/javascript-ui-nginx/charts/values.yaml
+++ b/packs/javascript-ui-nginx/charts/values.yaml
@@ -112,8 +112,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/javascript-ui-nginx/preview/Kptfile
+++ b/packs/javascript-ui-nginx/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/javascript-yarn/charts/templates/httproute.yaml
+++ b/packs/javascript-yarn/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/javascript-yarn/charts/templates/httproute.yaml
+++ b/packs/javascript-yarn/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/javascript-yarn/charts/templates/httproute.yaml
+++ b/packs/javascript-yarn/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/javascript-yarn/charts/templates/ingress.yaml
+++ b/packs/javascript-yarn/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/javascript-yarn/charts/values.yaml
+++ b/packs/javascript-yarn/charts/values.yaml
@@ -112,13 +112,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/javascript-yarn/charts/values.yaml
+++ b/packs/javascript-yarn/charts/values.yaml
@@ -139,6 +139,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/javascript-yarn/charts/values.yaml
+++ b/packs/javascript-yarn/charts/values.yaml
@@ -105,6 +105,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/javascript-yarn/charts/values.yaml
+++ b/packs/javascript-yarn/charts/values.yaml
@@ -112,8 +112,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/javascript-yarn/preview/Kptfile
+++ b/packs/javascript-yarn/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/javascript/charts/templates/httproute.yaml
+++ b/packs/javascript/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/javascript/charts/templates/httproute.yaml
+++ b/packs/javascript/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/javascript/charts/templates/httproute.yaml
+++ b/packs/javascript/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/javascript/charts/templates/ingress.yaml
+++ b/packs/javascript/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/javascript/charts/values.yaml
+++ b/packs/javascript/charts/values.yaml
@@ -112,13 +112,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/javascript/charts/values.yaml
+++ b/packs/javascript/charts/values.yaml
@@ -139,6 +139,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/javascript/charts/values.yaml
+++ b/packs/javascript/charts/values.yaml
@@ -105,6 +105,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/javascript/charts/values.yaml
+++ b/packs/javascript/charts/values.yaml
@@ -112,8 +112,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/javascript/preview/Kptfile
+++ b/packs/javascript/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/lookml/charts/Kptfile
+++ b/packs/lookml/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/lookml/charts/values.yaml
+++ b/packs/lookml/charts/values.yaml
@@ -3,20 +3,16 @@
 # Declare variables to be passed into your templates.
 looker:
   deployWebhookUrl: ""
-
 image:
   repository: curlimages/curl
   tag: 7.77.0
   pullPolicy: IfNotPresent
-
 # optional list of image pull secrets to use to pull images
 jx:
   # optional image pull secrets
   imagePullSecrets: []
-
   # whether to create a Release CRD when installing charts with Release CRDs included
   releaseCRD: true
-
 # Canary deployments
 # If enabled, Istio and Flagger need to be installed in the cluster
 canary:
@@ -39,7 +35,6 @@ canary:
   labels: {}
   # Add labels to the canary gateway
   gatewayLabels: {}
-
 resources:
   limits:
     cpu: 400m
@@ -47,7 +42,6 @@ resources:
   requests:
     cpu: 100m
     memory: 128Mi
-
 # values we use from the `jx-requirements.yml` file if we are using helmfile and helm 3
 jxRequirements:
   ingress:
@@ -56,7 +50,6 @@ jxRequirements:
     #  kubernetes.io/ingress.class: nginx
 
     apiVersion: "networking.k8s.io/v1"
-
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/maven-java11/charts/templates/httproute.yaml
+++ b/packs/maven-java11/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/maven-java11/charts/templates/httproute.yaml
+++ b/packs/maven-java11/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/maven-java11/charts/templates/httproute.yaml
+++ b/packs/maven-java11/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/maven-java11/charts/templates/ingress.yaml
+++ b/packs/maven-java11/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/maven-java11/charts/values.yaml
+++ b/packs/maven-java11/charts/values.yaml
@@ -115,8 +115,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/maven-java11/charts/values.yaml
+++ b/packs/maven-java11/charts/values.yaml
@@ -142,6 +142,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/maven-java11/charts/values.yaml
+++ b/packs/maven-java11/charts/values.yaml
@@ -108,6 +108,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/maven-java11/charts/values.yaml
+++ b/packs/maven-java11/charts/values.yaml
@@ -115,13 +115,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/maven-java11/preview/Kptfile
+++ b/packs/maven-java11/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/maven-java17/charts/templates/httproute.yaml
+++ b/packs/maven-java17/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/maven-java17/charts/templates/httproute.yaml
+++ b/packs/maven-java17/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/maven-java17/charts/templates/httproute.yaml
+++ b/packs/maven-java17/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/maven-java17/charts/templates/ingress.yaml
+++ b/packs/maven-java17/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/maven-java17/charts/values.yaml
+++ b/packs/maven-java17/charts/values.yaml
@@ -115,8 +115,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/maven-java17/charts/values.yaml
+++ b/packs/maven-java17/charts/values.yaml
@@ -142,6 +142,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/maven-java17/charts/values.yaml
+++ b/packs/maven-java17/charts/values.yaml
@@ -108,6 +108,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/maven-java17/charts/values.yaml
+++ b/packs/maven-java17/charts/values.yaml
@@ -115,13 +115,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/maven-java17/preview/Kptfile
+++ b/packs/maven-java17/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: 6b80dbd4eb04eaf9908fa94a88d0d8c233ce718d
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/maven-java21/charts/templates/httproute.yaml
+++ b/packs/maven-java21/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/maven-java21/charts/templates/httproute.yaml
+++ b/packs/maven-java21/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/maven-java21/charts/templates/httproute.yaml
+++ b/packs/maven-java21/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/maven-java21/charts/templates/ingress.yaml
+++ b/packs/maven-java21/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/maven-java21/charts/values.yaml
+++ b/packs/maven-java21/charts/values.yaml
@@ -115,8 +115,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/maven-java21/charts/values.yaml
+++ b/packs/maven-java21/charts/values.yaml
@@ -142,6 +142,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/maven-java21/charts/values.yaml
+++ b/packs/maven-java21/charts/values.yaml
@@ -108,6 +108,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/maven-java21/charts/values.yaml
+++ b/packs/maven-java21/charts/values.yaml
@@ -115,13 +115,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/maven-java21/preview/Kptfile
+++ b/packs/maven-java21/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: 6b80dbd4eb04eaf9908fa94a88d0d8c233ce718d
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/maven-java25/charts/templates/httproute.yaml
+++ b/packs/maven-java25/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/maven-java25/charts/templates/httproute.yaml
+++ b/packs/maven-java25/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/maven-java25/charts/templates/httproute.yaml
+++ b/packs/maven-java25/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/maven-java25/charts/templates/ingress.yaml
+++ b/packs/maven-java25/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/maven-java25/charts/values.yaml
+++ b/packs/maven-java25/charts/values.yaml
@@ -115,8 +115,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/maven-java25/charts/values.yaml
+++ b/packs/maven-java25/charts/values.yaml
@@ -142,6 +142,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/maven-java25/charts/values.yaml
+++ b/packs/maven-java25/charts/values.yaml
@@ -108,6 +108,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/maven-java25/charts/values.yaml
+++ b/packs/maven-java25/charts/values.yaml
@@ -115,13 +115,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/maven-java25/preview/Kptfile
+++ b/packs/maven-java25/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: 6b80dbd4eb04eaf9908fa94a88d0d8c233ce718d
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/maven-node-ruby/charts/templates/httproute.yaml
+++ b/packs/maven-node-ruby/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/maven-node-ruby/charts/templates/httproute.yaml
+++ b/packs/maven-node-ruby/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/maven-node-ruby/charts/templates/httproute.yaml
+++ b/packs/maven-node-ruby/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/maven-node-ruby/charts/templates/ingress.yaml
+++ b/packs/maven-node-ruby/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/maven-node-ruby/charts/values.yaml
+++ b/packs/maven-node-ruby/charts/values.yaml
@@ -112,13 +112,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/maven-node-ruby/charts/values.yaml
+++ b/packs/maven-node-ruby/charts/values.yaml
@@ -139,6 +139,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/maven-node-ruby/charts/values.yaml
+++ b/packs/maven-node-ruby/charts/values.yaml
@@ -105,6 +105,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/maven-node-ruby/charts/values.yaml
+++ b/packs/maven-node-ruby/charts/values.yaml
@@ -112,8 +112,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/maven-node-ruby/preview/Kptfile
+++ b/packs/maven-node-ruby/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/maven-quarkus-native/charts/templates/httproute.yaml
+++ b/packs/maven-quarkus-native/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/maven-quarkus-native/charts/templates/httproute.yaml
+++ b/packs/maven-quarkus-native/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/maven-quarkus-native/charts/templates/httproute.yaml
+++ b/packs/maven-quarkus-native/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/maven-quarkus-native/charts/templates/ingress.yaml
+++ b/packs/maven-quarkus-native/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/maven-quarkus-native/charts/values.yaml
+++ b/packs/maven-quarkus-native/charts/values.yaml
@@ -115,8 +115,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/maven-quarkus-native/charts/values.yaml
+++ b/packs/maven-quarkus-native/charts/values.yaml
@@ -142,6 +142,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/maven-quarkus-native/charts/values.yaml
+++ b/packs/maven-quarkus-native/charts/values.yaml
@@ -108,6 +108,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/maven-quarkus-native/charts/values.yaml
+++ b/packs/maven-quarkus-native/charts/values.yaml
@@ -115,13 +115,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/maven-quarkus-native/preview/Kptfile
+++ b/packs/maven-quarkus-native/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/maven-quarkus/charts/templates/httproute.yaml
+++ b/packs/maven-quarkus/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/maven-quarkus/charts/templates/httproute.yaml
+++ b/packs/maven-quarkus/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/maven-quarkus/charts/templates/httproute.yaml
+++ b/packs/maven-quarkus/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/maven-quarkus/charts/templates/ingress.yaml
+++ b/packs/maven-quarkus/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/maven-quarkus/charts/values.yaml
+++ b/packs/maven-quarkus/charts/values.yaml
@@ -115,8 +115,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/maven-quarkus/charts/values.yaml
+++ b/packs/maven-quarkus/charts/values.yaml
@@ -142,6 +142,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/maven-quarkus/charts/values.yaml
+++ b/packs/maven-quarkus/charts/values.yaml
@@ -108,6 +108,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/maven-quarkus/charts/values.yaml
+++ b/packs/maven-quarkus/charts/values.yaml
@@ -115,13 +115,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/maven-quarkus/preview/Kptfile
+++ b/packs/maven-quarkus/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/maven/charts/templates/httproute.yaml
+++ b/packs/maven/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/maven/charts/templates/httproute.yaml
+++ b/packs/maven/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/maven/charts/templates/httproute.yaml
+++ b/packs/maven/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/maven/charts/templates/ingress.yaml
+++ b/packs/maven/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/maven/charts/values.yaml
+++ b/packs/maven/charts/values.yaml
@@ -115,8 +115,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/maven/charts/values.yaml
+++ b/packs/maven/charts/values.yaml
@@ -142,6 +142,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/maven/charts/values.yaml
+++ b/packs/maven/charts/values.yaml
@@ -108,6 +108,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/maven/charts/values.yaml
+++ b/packs/maven/charts/values.yaml
@@ -115,13 +115,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/maven/preview/Kptfile
+++ b/packs/maven/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/ml-python-gpu-service/charts/templates/httproute.yaml
+++ b/packs/ml-python-gpu-service/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/ml-python-gpu-service/charts/templates/httproute.yaml
+++ b/packs/ml-python-gpu-service/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/ml-python-gpu-service/charts/templates/httproute.yaml
+++ b/packs/ml-python-gpu-service/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/ml-python-gpu-service/charts/templates/ingress.yaml
+++ b/packs/ml-python-gpu-service/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/ml-python-gpu-service/charts/values.yaml
+++ b/packs/ml-python-gpu-service/charts/values.yaml
@@ -141,6 +141,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/ml-python-gpu-service/charts/values.yaml
+++ b/packs/ml-python-gpu-service/charts/values.yaml
@@ -114,8 +114,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/ml-python-gpu-service/charts/values.yaml
+++ b/packs/ml-python-gpu-service/charts/values.yaml
@@ -114,13 +114,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/ml-python-gpu-service/charts/values.yaml
+++ b/packs/ml-python-gpu-service/charts/values.yaml
@@ -107,6 +107,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/ml-python-gpu-service/preview/Kptfile
+++ b/packs/ml-python-gpu-service/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/ml-python-gpu-training/charts/templates/httproute.yaml
+++ b/packs/ml-python-gpu-training/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/ml-python-gpu-training/charts/templates/httproute.yaml
+++ b/packs/ml-python-gpu-training/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/ml-python-gpu-training/charts/templates/httproute.yaml
+++ b/packs/ml-python-gpu-training/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/ml-python-gpu-training/charts/templates/ingress.yaml
+++ b/packs/ml-python-gpu-training/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/ml-python-gpu-training/charts/values.yaml
+++ b/packs/ml-python-gpu-training/charts/values.yaml
@@ -111,8 +111,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/ml-python-gpu-training/charts/values.yaml
+++ b/packs/ml-python-gpu-training/charts/values.yaml
@@ -104,6 +104,22 @@ ingress:
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   host: ""
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/ml-python-gpu-training/charts/values.yaml
+++ b/packs/ml-python-gpu-training/charts/values.yaml
@@ -139,6 +139,8 @@ jxRequirements:
     # For Kubernetes v1.14+, use 'networking.k8s.io/v1beta1'
     apiVersion: "extensions/v1beta1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/ml-python-gpu-training/charts/values.yaml
+++ b/packs/ml-python-gpu-training/charts/values.yaml
@@ -111,13 +111,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/ml-python-gpu-training/preview/Kptfile
+++ b/packs/ml-python-gpu-training/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/ml-python-service/charts/templates/httproute.yaml
+++ b/packs/ml-python-service/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/ml-python-service/charts/templates/httproute.yaml
+++ b/packs/ml-python-service/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/ml-python-service/charts/templates/httproute.yaml
+++ b/packs/ml-python-service/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/ml-python-service/charts/templates/ingress.yaml
+++ b/packs/ml-python-service/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/ml-python-service/charts/values.yaml
+++ b/packs/ml-python-service/charts/values.yaml
@@ -111,8 +111,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/ml-python-service/charts/values.yaml
+++ b/packs/ml-python-service/charts/values.yaml
@@ -104,6 +104,22 @@ ingress:
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   host: ""
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/ml-python-service/charts/values.yaml
+++ b/packs/ml-python-service/charts/values.yaml
@@ -139,6 +139,8 @@ jxRequirements:
     # For Kubernetes v1.14+, use 'networking.k8s.io/v1beta1'
     apiVersion: "extensions/v1beta1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/ml-python-service/charts/values.yaml
+++ b/packs/ml-python-service/charts/values.yaml
@@ -111,13 +111,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/ml-python-service/preview/Kptfile
+++ b/packs/ml-python-service/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/ml-python-training/charts/templates/httproute.yaml
+++ b/packs/ml-python-training/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/ml-python-training/charts/templates/httproute.yaml
+++ b/packs/ml-python-training/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/ml-python-training/charts/templates/httproute.yaml
+++ b/packs/ml-python-training/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/ml-python-training/charts/templates/ingress.yaml
+++ b/packs/ml-python-training/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/ml-python-training/charts/values.yaml
+++ b/packs/ml-python-training/charts/values.yaml
@@ -111,8 +111,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/ml-python-training/charts/values.yaml
+++ b/packs/ml-python-training/charts/values.yaml
@@ -104,6 +104,22 @@ ingress:
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   host: ""
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/ml-python-training/charts/values.yaml
+++ b/packs/ml-python-training/charts/values.yaml
@@ -139,6 +139,8 @@ jxRequirements:
     # For Kubernetes v1.14+, use 'networking.k8s.io/v1beta1'
     apiVersion: "extensions/v1beta1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/ml-python-training/charts/values.yaml
+++ b/packs/ml-python-training/charts/values.yaml
@@ -111,13 +111,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/ml-python-training/preview/Kptfile
+++ b/packs/ml-python-training/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/php/charts/templates/httproute.yaml
+++ b/packs/php/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/php/charts/templates/httproute.yaml
+++ b/packs/php/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/php/charts/templates/httproute.yaml
+++ b/packs/php/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/php/charts/templates/ingress.yaml
+++ b/packs/php/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/php/charts/values.yaml
+++ b/packs/php/charts/values.yaml
@@ -112,13 +112,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/php/charts/values.yaml
+++ b/packs/php/charts/values.yaml
@@ -139,6 +139,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/php/charts/values.yaml
+++ b/packs/php/charts/values.yaml
@@ -105,6 +105,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/php/charts/values.yaml
+++ b/packs/php/charts/values.yaml
@@ -112,8 +112,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/php/preview/Kptfile
+++ b/packs/php/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/python/charts/templates/httproute.yaml
+++ b/packs/python/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/python/charts/templates/httproute.yaml
+++ b/packs/python/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/python/charts/templates/httproute.yaml
+++ b/packs/python/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/python/charts/templates/ingress.yaml
+++ b/packs/python/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/python/charts/values.yaml
+++ b/packs/python/charts/values.yaml
@@ -112,13 +112,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/python/charts/values.yaml
+++ b/packs/python/charts/values.yaml
@@ -139,6 +139,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/python/charts/values.yaml
+++ b/packs/python/charts/values.yaml
@@ -105,6 +105,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/python/charts/values.yaml
+++ b/packs/python/charts/values.yaml
@@ -112,8 +112,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/python/preview/Kptfile
+++ b/packs/python/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/ruby/charts/templates/httproute.yaml
+++ b/packs/ruby/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/ruby/charts/templates/httproute.yaml
+++ b/packs/ruby/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/ruby/charts/templates/httproute.yaml
+++ b/packs/ruby/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/ruby/charts/templates/ingress.yaml
+++ b/packs/ruby/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/ruby/charts/values.yaml
+++ b/packs/ruby/charts/values.yaml
@@ -112,13 +112,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/ruby/charts/values.yaml
+++ b/packs/ruby/charts/values.yaml
@@ -139,6 +139,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/ruby/charts/values.yaml
+++ b/packs/ruby/charts/values.yaml
@@ -105,6 +105,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/ruby/charts/values.yaml
+++ b/packs/ruby/charts/values.yaml
@@ -112,8 +112,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/ruby/preview/Kptfile
+++ b/packs/ruby/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/rust/charts/templates/httproute.yaml
+++ b/packs/rust/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/rust/charts/templates/httproute.yaml
+++ b/packs/rust/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/rust/charts/templates/httproute.yaml
+++ b/packs/rust/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/rust/charts/templates/ingress.yaml
+++ b/packs/rust/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/rust/charts/values.yaml
+++ b/packs/rust/charts/values.yaml
@@ -112,13 +112,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/rust/charts/values.yaml
+++ b/packs/rust/charts/values.yaml
@@ -139,6 +139,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/rust/charts/values.yaml
+++ b/packs/rust/charts/values.yaml
@@ -105,6 +105,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/rust/charts/values.yaml
+++ b/packs/rust/charts/values.yaml
@@ -112,8 +112,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/rust/preview/Kptfile
+++ b/packs/rust/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/scala/charts/templates/httproute.yaml
+++ b/packs/scala/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/scala/charts/templates/httproute.yaml
+++ b/packs/scala/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/scala/charts/templates/httproute.yaml
+++ b/packs/scala/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/scala/charts/templates/ingress.yaml
+++ b/packs/scala/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/scala/charts/values.yaml
+++ b/packs/scala/charts/values.yaml
@@ -112,13 +112,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/scala/charts/values.yaml
+++ b/packs/scala/charts/values.yaml
@@ -139,6 +139,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/scala/charts/values.yaml
+++ b/packs/scala/charts/values.yaml
@@ -105,6 +105,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/scala/charts/values.yaml
+++ b/packs/scala/charts/values.yaml
@@ -112,8 +112,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/scala/preview/Kptfile
+++ b/packs/scala/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}

--- a/packs/typescript/charts/templates/httproute.yaml
+++ b/packs/typescript/charts/templates/httproute.yaml
@@ -29,7 +29,8 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
-{{- else }} []
+{{- else }}
+{{- fail "httpRoute.enabled is true but no parentRefs could be determined: set .Values.httpRoute.parentRefs explicitly, or set .Values.jxRequirements.ingress.kind to \"httproute\" to use the default envoy-gateway parentRefs." }}
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/typescript/charts/templates/httproute.yaml
+++ b/packs/typescript/charts/templates/httproute.yaml
@@ -20,7 +20,7 @@ spec:
   parentRefs:
 {{- if .Values.httpRoute.parentRefs }}
 {{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
-{{- else }}
+{{- else if eq .Values.jxRequirements.ingress.kind "httproute" }}
   - name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: http
@@ -29,6 +29,7 @@ spec:
     namespace: envoy-gateway-system
     sectionName: https
 {{- end }}
+{{- else }} []
 {{- end }}
 {{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
   hostnames:

--- a/packs/typescript/charts/templates/httproute.yaml
+++ b/packs/typescript/charts/templates/httproute.yaml
@@ -1,0 +1,53 @@
+{{- if and (.Values.httpRoute.enabled) (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- else }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/packs/typescript/charts/templates/ingress.yaml
+++ b/packs/typescript/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) (not .Values.httpRoute.enabled) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/packs/typescript/charts/values.yaml
+++ b/packs/typescript/charts/values.yaml
@@ -112,13 +112,15 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
+  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
   hostnames: []
-  # path prefix to match for the generated rule (overridden by the lighthouse webhook
-  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
   path: /
 
 serviceAccount:

--- a/packs/typescript/charts/values.yaml
+++ b/packs/typescript/charts/values.yaml
@@ -139,6 +139,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false

--- a/packs/typescript/charts/values.yaml
+++ b/packs/typescript/charts/values.yaml
@@ -105,6 +105,22 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  enabled: false
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when left empty
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule (overridden by the lighthouse webhook
+  # path "/<namespace>/hook" when jxRequirements.ingress.serviceType == NodePort)
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""

--- a/packs/typescript/charts/values.yaml
+++ b/packs/typescript/charts/values.yaml
@@ -112,8 +112,8 @@ httpRoute:
   # Add labels to the route
   labels: {}
   # list of resources to attach the route to (usually a Gateway)
-  # when left empty, defaults to the platform Gateway (envoy-gateway) only when
-  # jxRequirements.ingress.kind == "httproute"; otherwise no parentRefs are set
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
   # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
   parentRefs: []
   # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain

--- a/packs/typescript/preview/Kptfile
+++ b/packs/typescript/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 8bc564f892b2bb7cbb7b57ce74c85423fa155c25
+pipeline: {}


### PR DESCRIPTION
### Changes
* Add `httproute.yaml` templates in the charts found under `/packs`
* Add `httproute` block to values.yaml for activating HTTPRoutes
* Edit `ingress.yaml` templates to to check `httpRoute.enabled` in values

### Context

Support Gateway API HTTPRoutes as an alternative to Ingress under the chart templates. Switch over by setting `httpRoute.enabled: true`.

When `Values.jxRequirements.ingress.kind: httproute`, Envoy Gateway is set as the `parentRef`. I note here that this integration within JX is incomplete but worth adding here as a starter before adding more functionality upstream.

This impacts more than 40 packs, so this is a large PR.

To test these changes locally, you can template a pack using helm:

```
helm template x packs/cwp/charts --show-only templates/httproute.yaml --set service.name=x --set httpRoute.enabled=true --set jxRequirements.ingress.domain=example.com --set jxRequirements.ingress.kind=httproute
```

part of https://github.com/jenkins-x/jx/issues/8962

