### PR TITLE
chore: update kpt API version to v1 in packs

### DIFF
--- a/packs/C++/charts/Kptfile
+++ b/packs/C++/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/C++/preview/Kptfile
+++ b/packs/C++/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/D/charts/Kptfile
+++ b/packs/D/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/D/preview/Kptfile
+++ b/packs/D/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/appserver/charts/Kptfile
+++ b/packs/appserver/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/appserver/preview/Kptfile
+++ b/packs/appserver/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/csharp/charts/Kptfile
+++ b/packs/csharp/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/csharp/preview/Kptfile
+++ b/packs/csharp/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/cwp/charts/Kptfile
+++ b/packs/cwp/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/cwp/preview/Kptfile
+++ b/packs/cwp/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/go-mongodb/charts/Kptfile
+++ b/packs/go-mongodb/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/go-mongodb/preview/Kptfile
+++ b/packs/go-mongodb/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/go/charts/Kptfile
+++ b/packs/go/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/go/preview/Kptfile
+++ b/packs/go/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/gradle/charts/Kptfile
+++ b/packs/gradle/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/gradle/preview/Kptfile
+++ b/packs/gradle/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/javascript-ui-nginx/charts/Kptfile
+++ b/packs/javascript-ui-nginx/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/javascript-ui-nginx/preview/Kptfile
+++ b/packs/javascript-ui-nginx/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/javascript-yarn/charts/Kptfile
+++ b/packs/javascript-yarn/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/javascript-yarn/preview/Kptfile
+++ b/packs/javascript-yarn/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/javascript/charts/Kptfile
+++ b/packs/javascript/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/javascript/preview/Kptfile
+++ b/packs/javascript/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/lookml/charts/Kptfile
+++ b/packs/lookml/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/maven-java11/charts/Kptfile
+++ b/packs/maven-java11/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/maven-java11/preview/Kptfile
+++ b/packs/maven-java11/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/maven-java17/charts/Kptfile
+++ b/packs/maven-java17/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/maven-java17/preview/Kptfile
+++ b/packs/maven-java17/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: 6b80dbd4eb04eaf9908fa94a88d0d8c233ce718d
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/maven-java21/charts/Kptfile
+++ b/packs/maven-java21/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/maven-java21/preview/Kptfile
+++ b/packs/maven-java21/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: 6b80dbd4eb04eaf9908fa94a88d0d8c233ce718d
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/maven-java25/charts/Kptfile
+++ b/packs/maven-java25/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/maven-java25/preview/Kptfile
+++ b/packs/maven-java25/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: 6b80dbd4eb04eaf9908fa94a88d0d8c233ce718d
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/maven-node-ruby/charts/Kptfile
+++ b/packs/maven-node-ruby/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/maven-node-ruby/preview/Kptfile
+++ b/packs/maven-node-ruby/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/maven-quarkus-native/charts/Kptfile
+++ b/packs/maven-quarkus-native/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/maven-quarkus-native/preview/Kptfile
+++ b/packs/maven-quarkus-native/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/maven-quarkus/charts/Kptfile
+++ b/packs/maven-quarkus/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/maven-quarkus/preview/Kptfile
+++ b/packs/maven-quarkus/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/maven/charts/Kptfile
+++ b/packs/maven/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/maven/preview/Kptfile
+++ b/packs/maven/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/ml-python-gpu-service/charts/Kptfile
+++ b/packs/ml-python-gpu-service/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/ml-python-gpu-service/preview/Kptfile
+++ b/packs/ml-python-gpu-service/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/ml-python-gpu-training/charts/Kptfile
+++ b/packs/ml-python-gpu-training/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/ml-python-gpu-training/preview/Kptfile
+++ b/packs/ml-python-gpu-training/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/ml-python-service/charts/Kptfile
+++ b/packs/ml-python-service/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/ml-python-service/preview/Kptfile
+++ b/packs/ml-python-service/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/ml-python-training/charts/Kptfile
+++ b/packs/ml-python-training/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/ml-python-training/preview/Kptfile
+++ b/packs/ml-python-training/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/php/charts/Kptfile
+++ b/packs/php/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/php/preview/Kptfile
+++ b/packs/php/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/python/charts/Kptfile
+++ b/packs/python/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/python/preview/Kptfile
+++ b/packs/python/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/ruby/charts/Kptfile
+++ b/packs/ruby/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/ruby/preview/Kptfile
+++ b/packs/ruby/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/rust/charts/Kptfile
+++ b/packs/rust/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/rust/preview/Kptfile
+++ b/packs/rust/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/scala/charts/Kptfile
+++ b/packs/scala/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/scala/preview/Kptfile
+++ b/packs/scala/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}

--- a/packs/typescript/charts/Kptfile
+++ b/packs/typescript/charts/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: charts
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/charts
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/charts
+    ref: master
+    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
+pipeline: {}

--- a/packs/typescript/preview/Kptfile
+++ b/packs/typescript/preview/Kptfile
@@ -1,11 +1,19 @@
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: preview
 upstream:
   type: git
   git:
-    commit: b52b35506a05e046d54615c3ade97f3aef8bfb08
     repo: https://github.com/jenkins-x/jx3-pipeline-catalog
     directory: /helm/preview
     ref: master
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/jenkins-x/jx3-pipeline-catalog
+    directory: /helm/preview
+    ref: master
+    commit: 3ccbaf005573a0069e7e31e5adcc7a49eb89580c
+pipeline: {}


### PR DESCRIPTION
### Changes

* Update kpt API version to `v1` in `packs/` dirs

### Context

Ran `jx gitops kpt update --ignore-yaml-error` (same as `jx gitops upgrade --ignore-yaml-error`) after a fix was applied to jx-gitops (https://github.com/jenkins-x-plugins/jx-gitops/pull/1086)
