### PR TITLE
feat: add HTTPRoute template to helm dir

### DIFF
--- a/helm/charts/templates/httproute.yaml
+++ b/helm/charts/templates/httproute.yaml
@@ -1,0 +1,52 @@
+{{- if and (eq .Values.jxRequirements.ingress.kind "httproute") (or .Values.httpRoute.hostnames .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- $annotations := dict }}
+{{- $_ := merge $annotations .Values.httpRoute.annotations .Values.jxRequirements.ingress.annotations }}
+{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- if $annotations }}
+  annotations:
+{{ toYaml $annotations | indent 4 }}
+{{- end }}
+  name: {{ .Values.service.name }}
+{{- if .Values.httpRoute.labels }}
+  labels:
+{{ toYaml .Values.httpRoute.labels | indent 4 }}
+{{- end }}
+spec:
+  parentRefs:
+{{- if .Values.httpRoute.parentRefs }}
+{{ toYaml .Values.httpRoute.parentRefs | indent 2 }}
+{{- end }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: http
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+  - name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+{{- end }}
+{{- if not (eq "NodePort" .Values.jxRequirements.ingress.serviceType) }}
+  hostnames:
+{{- if .Values.httpRoute.hostnames }}
+{{ toYaml .Values.httpRoute.hostnames | indent 2 }}
+{{- else }}
+  - {{ printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain | quote }}
+{{- end }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
+        value: "/{{ .Release.Namespace }}/hook"
+{{- else }}
+        value: {{ .Values.httpRoute.path | default "/" }}
+{{- end }}
+    backendRefs:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+{{- end }}

--- a/helm/charts/templates/ingress.yaml
+++ b/helm/charts/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
+{{- if and (ne .Values.jxRequirements.ingress.kind "httproute") (or .Values.ingress.host .Values.jxRequirements.ingress.domain) (not .Values.knativeDeploy) }}
 {{- $host := (.Values.ingress.host | default (printf "%s%s%s" .Values.service.name .Values.jxRequirements.ingress.namespaceSubDomain .Values.jxRequirements.ingress.domain)) | quote }}
 {{- $annotations := dict }}
 {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}

--- a/helm/charts/values.yaml
+++ b/helm/charts/values.yaml
@@ -105,6 +105,23 @@ ingress:
   # ingress path type
   pathType: ImplementationSpecific
 
+httpRoute:
+  # Add annotations to the route (merged with jxRequirements.ingress.annotations)
+  annotations: {}
+  # Add labels to the route
+  labels: {}
+  # list of resources to attach the route to (usually a Gateway)
+  # defaults to the platform Gateway (envoy-gateway) when jxRequirements.ingress.kind == "httproute";
+  # otherwise, fails if parentRefs are not set
+  # https://gateway-api.sigs.k8s.io/reference/api-spec/1.5/spec/#httproutespec
+  parentRefs: []
+  # defaults to .service.name + jxRequirements.ingress.namespaceSubDomain + jxRequirements.ingress.domain
+  hostnames: []
+  # path prefix to match for the generated rule. When
+  # jxRequirements.ingress.serviceType == NodePort this is overridden by the
+  # lighthouse webhook path "/<namespace>/hook".
+  path: /
+
 serviceAccount:
   enabled: true
   name: ""
@@ -123,6 +140,8 @@ jxRequirements:
 
     apiVersion: "networking.k8s.io/v1"
 
+    kind: ""
+
     # the domain for hosts
     domain: ""
     externalDNS: false
@@ -133,5 +152,4 @@ jxRequirements:
       enabled: false
       production: false
       secretName: ""
-
 


### PR DESCRIPTION
### Changes

* Create `HTTPRoute` template at `helm/charts/templates/httproute.yaml`
* Add ingress kind check to `Ingress` template
* Add `httpRoute` block to values.yaml`

### Context

Create an optional `HTTPRoute` helm template.

When `jxRequirements.ingress.kind: httproute`, a `HTTPRoute` resource is deployed instead of the default `Ingress` resource.

The new templates will be distributed to `packs/` in a follow-up PR - kpt will pick up and deploy the changes from the head commit.